### PR TITLE
Resolve lifetime error in `Document::root_element`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl<'input> Document<'input> {
     /// assert!(doc.root_element().has_tag_name("e"));
     /// ```
     #[inline]
-    pub fn root_element(&self) -> Node {
+    pub fn root_element<'a>(&'a self) -> Node<'a, 'input> {
         // `unwrap` is safe, because the `Document` is guarantee to have at least one element.
         self.root().first_element_child().unwrap()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,10 +148,6 @@ impl<'input> fmt::Debug for Document<'input> {
                 writeln!($f, $fmt)?;
             };
             ($depth:expr, $f:expr, $fmt:expr, $($arg:tt)*) => {
-                // The `depth + 1` call below causes this macro to expand into a
-                // syntax that trips a Clippy lint, but the suggested fix is
-                // incorrect for this case.
-                #[allow(clippy::range_plus_one)]
                 for _ in 0..$depth { write!($f, "    ")?; }
                 writeln!($f, $fmt, $($arg)*)?;
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,10 @@ impl<'input> fmt::Debug for Document<'input> {
                 writeln!($f, $fmt)?;
             };
             ($depth:expr, $f:expr, $fmt:expr, $($arg:tt)*) => {
+                // The `depth + 1` call below causes this macro to expand into a
+                // syntax that trips a Clippy lint, but the suggested fix is
+                // incorrect for this case.
+                #[allow(clippy::range_plus_one)]
                 for _ in 0..$depth { write!($f, "    ")?; }
                 writeln!($f, $fmt, $($arg)*)?;
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ impl<'input> Document<'input> {
     /// ```
     #[inline]
     pub fn root_element<'a>(&'a self) -> Node<'a, 'input> {
-        // `unwrap` is safe, because the `Document` is guarantee to have at least one element.
+        // `expect` is safe, because the `Document` is guarantee to have at least one element.
         self.root().first_element_child().expect("XML documents must contain a root element")
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl<'input> Document<'input> {
     #[inline]
     pub fn root_element<'a>(&'a self) -> Node<'a, 'input> {
         // `unwrap` is safe, because the `Document` is guarantee to have at least one element.
-        self.root().first_element_child().unwrap()
+        self.root().first_element_child().expect("XML documents must contain a root element")
     }
 
     /// Returns an iterator over document's descendant nodes.


### PR DESCRIPTION
There are three commits in this patch; only the first is material. The other two may be removed or kept at your discretion.

Currently, the following code fails to compile:

```rust
use roxmltree::{Document, Node};

pub struct Manifest<'src> {
  xml: Document<'src>,
}

impl<'src> Manifest<'src> {
  pub fn root_node(&self) -> Node<'_, 'src> {
    self.xml.root_element()
  }
}
```

because of lifetime mismatches. However, the *equivalent* code,

```rust
impl<'src> Manifest<'src> {
  pub fn root_node(&self) -> Node<'_, 'src> {
    self.xml.root().first_element_child().unwrap()
  }
}
```

*does* compile.

This is because the definitions of `Document::root` and `Node::first_element_child` explicitly thread lifetimes, but the definition of `Document::root_element` does not. This causes the compiler to incorrectly attach shorter lifetimes to the returned `Node` of `Document::root_element`.

This patch explicitly provides `'input` and `'a` lifetimes to `Document::root_element`, matching `Document::root`, so that this error is resolved.