### PR TITLE
Change Rc to Arc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ extern crate xmlparser;
 use std::borrow::Cow;
 use std::fmt;
 use std::ops::Deref;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use xmlparser::TextPos;
 
@@ -469,12 +469,12 @@ impl<'input> Deref for Namespaces<'input> {
 }
 
 
-struct Uri(Rc<String>);
+struct Uri(Arc<String>);
 
 impl Uri {
     #[inline]
     fn new(text: String) -> Self {
-        Uri(Rc::new(text))
+        Uri(Arc::new(text))
     }
 
     #[inline]
@@ -486,7 +486,7 @@ impl Uri {
 impl Clone for Uri {
     #[inline]
     fn clone(&self) -> Self {
-        Uri(Rc::clone(&self.0))
+        Uri(Arc::clone(&self.0))
     }
 }
 


### PR DESCRIPTION
Making this change should allow multi-threading with libraries like rayon.
For example, the following code compiles in this branch but not on `master`:
```rust
use std::fs;
use roxmltree::Document;
use rayon::prelude::*;

fn main() {
  let xml = fs::read_to_string("./document.xhtml").unwrap();
  let doc = Document::parse(&xml).unwrap();
  let root = doc.root();

  (0..1000).into_par_iter().for_each(|_| {
    root.descendants().filter(|node| {
      node.tag_name().name() == "p"
    }).count();
  });
}
```
The speed up from `into_par_iter` can be very significant (3.7s vs 14.2s on my machine) if you are walking the tree a bunch of times (let's pretend that we are looking for different items each iteration in the example above).

After running `cargo bench` and running the non-parallel version of this code through both this branch and `master`, there was no significant difference in the run times. So this seems like it might a lot a benefit in some use cases for very little cost.