### PR TITLE
Idea: Guarantee NodeId is in document order

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ There is also `elementtree` and `treexml` crates, but they are abandoned for a l
 
 ## Performance
 
+### Parsing
+
 ```text
 test large_roxmltree     ... bench:   3,344,633 ns/iter (+/- 9,063)
 test large_minidom       ... bench:   5,101,156 ns/iter (+/- 98,146)
@@ -122,9 +124,25 @@ test tiny_xmlparser      ... bench:       2,578 ns/iter (+/- 931)
 test tiny_xmlrs          ... bench:      27,343 ns/iter (+/- 3,299)
 ```
 
-You can try it yourself by running `cargo bench` in the `benches` dir.
+### Iteration
 
-Notes:
+```text
+test minidom_iter_descendants_expensive     ... bench:   1,004,545 ns/iter (+/- 178,395)
+test roxmltree_iter_descendants_expensive   ... bench:     694,561 ns/iter (+/- 139,937)
+test xmltree_iter_descendants_expensive     ... bench:     624,414 ns/iter (+/- 158,466)
+
+test minidom_iter_descendants_inexpensive   ... bench:     299,906 ns/iter (+/- 77,093)
+test roxmltree_iter_descendants_inexpensive ... bench:      64,251 ns/iter (+/- 8,589)
+test xmltree_iter_descendants_inexpensive   ... bench:     264,602 ns/iter (+/- 112,251)
+```
+where expensive refers to the matching done on each element. In these
+benchmarks, 'expensive' means searching for any node in the document which
+contains a string. and 'inexpensive' means searching for any element with a
+particular name.
+
+### Notes
+
+You can try running the benchmarks yourself by running `cargo bench` in the `benches` dir.
 
 - Since all libraries have a different XML support, benchmarking is a bit pointless.
 - Tree crates may use different *xml-rs* crate versions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ License: ISC.
 extern crate xmlparser;
 
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::ops::Deref;
@@ -570,7 +571,25 @@ impl<'input> From<(&'input str, &'input str)> for ExpandedName<'input> {
 }
 
 
-/// A node.
+/// A node in a document.
+///
+/// ### Document Order
+/// The impl of the `Ord` traits for Node is based on the concept of "document-order".
+/// In layman's terms, document-order is the order in which one would see each element if
+/// one opened a document in a text editor or web browser and scrolled down.
+/// Document-order convention is followed in XPath, CSS Counters, and DOM selectors API
+/// to ensure consistent results from selection.
+/// One difference in roxmltree is that there is the notion of more than one document
+/// in existence at a time. While Nodes within the same document are in document-order,
+/// Nodes in different documents will be grouped together, but not in any particular
+/// order.
+/// As an example, if we have a Document `a` with Nodes `[a0, a1, a2]` and a
+/// Document `b` with Nodes `[b0, b1]`, these Nodes in order could be either
+/// `[a0, a1, a2, b0, b1]` or `[b0, b1, a0, a1, a2]` and roxmltree makes no
+/// guarantee which it will be.
+/// Document-order is defined here in the [W3C XPath Recommendation](https://www.w3.org/TR/xpath-3/#id-document-order)
+/// The use of document-order in DOM Selectors is described here in the
+/// [W3C Selectors API Level 1](https://www.w3.org/TR/selectors-api/#the-apis)
 #[derive(Clone, Copy)]
 pub struct Node<'a, 'input: 'a> {
     /// Node ID.
@@ -590,6 +609,26 @@ impl<'a, 'input> PartialEq for Node<'a, 'input> {
            self.id == other.id
         && self.doc as *const _ == other.doc as *const _
         && self.d as *const _ == other.d as *const _
+    }
+}
+
+impl<'a, 'input> PartialOrd for Node<'a, 'input> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a, 'input> Ord for Node<'a, 'input> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let id_cmp = self.id.0.cmp(&other.id.0);
+        match id_cmp {
+            Ordering::Equal => {
+                let this_doc_ptr = self.doc as *const Document;
+                let other_doc_ptr = other.doc as *const Document;
+                this_doc_ptr.cmp(&other_doc_ptr)
+            },
+            _ => id_cmp
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ struct NodeData<'input> {
     parent: Option<NodeId>,
     prev_sibling: Option<NodeId>,
     next_sibling: Option<NodeId>,
-    children: Option<(NodeId, NodeId)>,
+    last_child: Option<NodeId>,
     kind: NodeKind<'input>,
     range: Range,
 }
@@ -984,7 +984,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     /// Returns the first child of this node.
     #[inline]
     pub fn first_child(&self) -> Option<Self> {
-        self.d.children.map(|(id, _)| self.gen_node(id))
+        self.d.last_child.map(|_| self.gen_node(NodeId::new(self.id.get() + 1)))
     }
 
     /// Returns the first element child of this node.
@@ -995,7 +995,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     /// Returns the last child of this node.
     #[inline]
     pub fn last_child(&self) -> Option<Self> {
-        self.d.children.map(|(_, id)| self.gen_node(id))
+        self.d.last_child.map(|id| self.gen_node(id))
     }
 
     /// Returns the last element child of this node.
@@ -1012,7 +1012,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     /// Returns true if this node has children.
     #[inline]
     pub fn has_children(&self) -> bool {
-        self.d.children.is_some()
+        self.d.last_child.is_some()
     }
 
     /// Returns an iterator over ancestor nodes starting at this node.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -220,25 +220,18 @@ impl<'input> Document<'input> {
             parent: Some(parent_id),
             prev_sibling: None,
             next_sibling: None,
-            children: None,
+            last_child: None,
             kind,
             range,
         });
 
-        let last_child_id = self.nodes[parent_id.get()].children.map(|(_, id)| id);
+        let last_child_id = self.nodes[parent_id.get()].last_child;
         self.nodes[new_child_id.get()].prev_sibling = last_child_id;
+        self.nodes[parent_id.get()].last_child = Some(new_child_id);
 
         if let Some(id) = last_child_id {
             self.nodes[id.get()].next_sibling = Some(new_child_id);
         }
-
-        self.nodes[parent_id.get()].children = Some(
-            if let Some((first_child_id, _)) = self.nodes[parent_id.get()].children {
-                (first_child_id, new_child_id)
-            } else {
-                (new_child_id, new_child_id)
-            }
-        );
 
         new_child_id
     }
@@ -386,7 +379,7 @@ fn parse(text: &str) -> Result<Document, Error> {
         parent: None,
         prev_sibling: None,
         next_sibling: None,
-        children: None,
+        last_child: None,
         kind: NodeKind::Root,
         range: 0..text.len(),
     });

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -221,6 +221,23 @@ fn next_prev_element_01() {
 }
 
 #[test]
+fn nodes_document_order() {
+    let data = "<root><a/><b/><c/></root>";
+
+    let doc = roxmltree::Document::parse(data).unwrap();
+    let root = doc.root_element();
+    let a = root.first_element_child().unwrap();
+    let b = a.next_sibling_element().unwrap();
+    let c = b.next_sibling_element().unwrap();
+
+    let mut elems = vec![&b, &c, &a];
+    elems.sort();
+    assert!(elems[0] == &a);
+    assert!(elems[1] == &b);
+    assert!(elems[2] == &c);
+}
+
+#[test]
 fn lifetimes() {
     fn f<'a, 'd, F, R>(doc: &'a roxmltree::Document<'d>, fun: F) -> R
         where F: Fn(&'a roxmltree::Document<'d>) -> R


### PR DESCRIPTION
Hi again!

Since a roxmltree document is read-only, it seems like there are some fairly safe ways that we can take advantage of the order of `NodeId`, since their relationships should never change over the lifetime of the tree. I've made this PR as an example to start a discussion of what benefits that might be drawn from guaranteeing that `NodeId` represents the order of the document.

Some benefits:
1. Implementing the `Ord`/`PartialOrd` traits for depth-first order is trivial. If `Hash` is also implemented for Node, then it can potentially be stored in collections like `BTreeMap`, which could be helpful for anyone making complex selections in a document or for anyone writing selection languages that work on a roxmltree document (I know xpath implementation is a non-goal of this project, but this makes it possible for roxmltree act as the backing representation for something that does make selections).
2. We no longer have to store first child in `NodeData` structs, since it should always be at `self.id + 1` if the node has children. This could lead to some memory savings.
3. There are both benefits and drawbacks for replacing `next_sibling` with `next_subtree` (i.e. the `NodeId` which represents the next node in document order that is not a descendant of the current node). The benefit would be that optimization can be made to the `Descendants` iterator to make it much faster, since it simply has to iterate through NodeId values (takes roughly 50% of the time on my system, which seems like colossal savings!). The drawback of this might be that it reverses some of the savings that we get from not storing the first child in `NodeData` because it does about the same amount of work during parsing, and it is less likely to be `None` than `next_sibling` (I don't actually know enough about the layout of `Option` to know if that matters, perhaps the recent change to `NonZeroUSize` for `NodeId` makes it take up the size either way?). The `next_sibling()` function may also take a slight hit in performance. Maybe this sort of optimization is only worth doing for the root node, but I thought I would mention it, since Descendants is typically a fairly expensive operation and I was seeing such large improvements for it.

Thoughts?