### PR TITLE
Expose NodeId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,30 @@ impl<'input> Document<'input> {
         Node { id: NodeId::new(0), d: &self.nodes[0], doc: self }
     }
 
+    /// Returns the node of the tree with the given NodeId.
+    /// 
+    /// Note: NodeId::new(0) represents the root node
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// let doc = roxmltree::Document::parse("\
+    /// <p>
+    ///     text
+    /// </p>
+    /// ").unwrap();
+    /// 
+    /// use roxmltree::NodeId;
+    /// assert_eq!(doc.get_node(NodeId::new(0)).unwrap(), doc.root());
+    /// assert_eq!(doc.get_node(NodeId::new(1)), doc.descendants().find(|n| n.has_tag_name("p")));
+    /// assert_eq!(doc.get_node(NodeId::new(2)), doc.descendants().find(|n| n.is_text()));
+    /// assert_eq!(doc.get_node(NodeId::new(3)), None);
+    /// ```
+    #[inline]
+    pub fn get_node<'a>(&'a self, id: NodeId) -> Option<Node<'a, 'input>> {
+        self.nodes.get(id.get()).map(|data| Node { id, d: data, doc: self })
+    }
+
     /// Returns the root element of the document.
     ///
     /// Unlike `root`, will return a first element node.
@@ -251,19 +275,19 @@ pub struct PI<'input> {
 /// A node ID.
 ///
 /// Index into a `Tree`-internal `Vec`.
-///
-/// By using `NonZeroUsize` we can fit `Option<NodeId>` into a single byte.
-#[derive(Clone, Copy, PartialEq)]
-struct NodeId(NonZeroUsize);
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct NodeId(NonZeroUsize);
 
 impl NodeId {
+    /// Construct a NodeId from a usize
     #[inline]
-    fn new(n: usize) -> Self {
+    pub fn new(n: usize) -> Self {
         NodeId(NonZeroUsize::new(n + 1).unwrap())
     }
 
+    /// Get the usize representation of the NodeId
     #[inline]
-    fn get(self) -> usize {
+    pub fn get(self) -> usize {
         self.0.get() - 1
     }
 }
@@ -1115,6 +1139,12 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     #[inline]
     pub fn range(&self) -> Range {
         self.d.range.clone()
+    }
+
+    /// Returns node's NodeId
+    #[inline]
+    pub fn id(&self) -> NodeId {
+        self.id
     }
 }
 


### PR DESCRIPTION
I expect to get some pushback on this, but currently this is the last thing that I need (for my use case) to use a fork of roxmltree for, instead of using this branch, so I would be upset with myself if I didn't try a PR :)

**Contents**
This PR add three methods:
1. `Document::nth_node` - which takes a usize `n` and returns the Node at `n` in document-order
2. `Node::order_in_document` - which is the reverse operation of `Document::nth_node`, returns the usize `n` for which `Document::nth_node` returns this node
3. `Document::len` - which returns the number of nodes in the document. I don't really care too much about this one, but it seemed related and currently the quickest way to get this value with the public API is `doc.descendants().count()`, which is a bit odd. I used this method for the doctest for `Node::order_in_document` because it was easier :P

**Reasoning**
My particular use case involves needing to serialize Nodes for IPC. I needed a reversible conversion between `Node` and some type `T` in which `T` is serializable and unique per `Node` in a document. Since `NodeId` is stored already, is unique per `Node` in a document, and has an interface that utilizes usize, it seemed like usize could be the type `T` that I am looking for and that public methods could be exposed that both provided me the conversion I need, and have semantic meaning that does not expose internals like `NodeId` itself.

As far as I can tell, this can _technically_ be implemented with the public API of roxmltree, but it would be very inefficient - i.e. it would require doing something like `Vec<Node>` (for usize -> Node) AND a `HashMap<Node, usize>` (for Node -> usize) with potentially every Node in the document. Perhaps I am missing something easier. Any thoughts?