### PR TITLE
Namespace efficiency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ impl<'input> fmt::Debug for Document<'input> {
                     writeln_indented!(depth, f, "Element {{");
                     writeln_indented!(depth, f, "    tag_name: {:?}", child.tag_name());
                     print_vec("attributes", child.attributes(), depth + 1, f)?;
-                    print_vec("namespaces", child.namespaces(), depth + 1, f)?;
+                    print_vec("namespaces", &child.namespaces(), depth + 1, f)?;
 
                     if child.has_children() {
                         writeln_indented!(depth, f, "    children: [");
@@ -298,7 +298,7 @@ enum NodeKind<'input> {
     Element {
         tag_name: ExpandedNameOwned<'input>,
         attributes: Range,
-        namespaces: Range,
+        namespaces: Vec<usize>,
     },
     PI(PI<'input>),
     Comment(&'input str),
@@ -918,12 +918,17 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     /// assert_eq!(doc.root_element().namespaces().len(), 1);
     /// ```
     #[inline]
-    pub fn namespaces(&self) -> &'a [Namespace<'input>] {
+    pub fn namespaces(&self) -> Vec<&'a Namespace<'input>> {
         match self.d.kind {
             NodeKind::Element { ref namespaces, .. } => {
-                &self.doc.namespaces[namespaces.clone()]
+                namespaces
+                    .iter()
+                    .map(|i| {
+                        &self.doc.namespaces[*i]
+                    })
+                    .collect()
             }
-            _ => &[],
+            _ => vec![],
         }
     }
 


### PR DESCRIPTION
I thought I'd try my hand at addressing #25. This PR probably still needs some work and discussion, but I thought it would serve as a decent proof of concept.

**Rationale**
It seems that documents with either

1. a lot of namespaces
2. a large size with at least a couple namespaces

were being inflated in size in memory.

This PR tries to reduce memory consumption by only storing each _unique_ namespace declaration within `Document.namespaces` storing a `Vec<usize>` for each node instead of a `Range`, containing indices referencing namespaces in `Document.namespaces`. This does not use _strictly_ less memory than before, but provides excellent savings when roxmltree tends to consume lots of memory from namespaces.

**Examples**

Here's a rundown of maximum memory usage on master and on this branch (I used valgrind to measure memory usage):

 _Peak Memory Usage in MB_
| | Master | This Branch |
|----------------------------------------|--------|-------------|
| large.plist (no root namespace)        | 9.8    | 10.1        |
| large.plist (with root namespace)      | 10.6   | 10.3        |
| large.plist (2 root namespaces)        | 11.3   | 10.3        |
| large.plist (3 root namespaces)        | 12.8   | 10.5        |
| | |
| book.xhtml (12 MB + 2 root namespaces) | 217.4  | 135.9       |
| book.xhtml (3 root namespaces)         | 217.4**  | 140.9       |
| book.xhtml (4 root namespaces)         | 313.4  | 140.9       |

** - Not sure why this is the case, but I double checked this one. I have no idea...

**Parsing Performance**
Since we can just merge the namespace indices of the currently parsed node with its parent's, reducing we can get a noticeable speed-up during parsing for large/namespace-rich documents (commit 0c1db61). In particular, the most gains are in `medium` (I assume since it's the only bench document with namespace declarations), with possible benefits for `large`, and potentially a small slowdown in `tiny`

Here are three consecutive benchmark runs:

_BEFORE_
```
test large_roxmltree                        ... bench:   4,500,096 ns/iter (+/- 173,435)
test medium_roxmltree                       ... bench:     948,893 ns/iter (+/- 36,222)
test tiny_roxmltree                         ... bench:       4,640 ns/iter (+/- 131)

test large_roxmltree                        ... bench:   4,825,849 ns/iter (+/- 338,981)
test medium_roxmltree                       ... bench:     991,011 ns/iter (+/- 93,786)
test tiny_roxmltree                         ... bench:       4,906 ns/iter (+/- 244)

test large_roxmltree                        ... bench:   4,469,187 ns/iter (+/- 288,316)
test medium_roxmltree                       ... bench:     938,886 ns/iter (+/- 142,450)
test tiny_roxmltree                         ... bench:       4,515 ns/iter (+/- 212)
```

_AFTER_
```
test large_roxmltree                        ... bench:   4,428,082 ns/iter (+/- 232,850)
test medium_roxmltree                       ... bench:     862,197 ns/iter (+/- 17,036)
test tiny_roxmltree                         ... bench:       4,758 ns/iter (+/- 210)

test large_roxmltree                        ... bench:   4,418,364 ns/iter (+/- 168,545)
test medium_roxmltree                       ... bench:     868,548 ns/iter (+/- 34,701)
test tiny_roxmltree                         ... bench:       4,752 ns/iter (+/- 262)

test large_roxmltree                        ... bench:   4,549,643 ns/iter (+/- 179,861)
test medium_roxmltree                       ... bench:     886,984 ns/iter (+/- 16,533)
test tiny_roxmltree                         ... bench:       4,929 ns/iter (+/- 173)
```

**Drawbacks**
This change is NOT backwards compatible. `Node::namespaces()` can no longer return a `&[Namespace]`, since new continuous allocations are no longer made per each node. Instead a `Vec<&Namespace>` is returned, because the backing `Vec<usize>` is resolved and collected. I'm not sure how to avoid this backward compatibility issue without intentionally leaking memory to provide a slice. I don't know the policy for breaking changes on this project, so there may be some discussion needed.

**Testing**
While this passes all the existing tests, because this seems like a pretty weighty change, it might be a good idea to include a more thorough regression test for this.