### PR TITLE
Make `roxmltree::Error` compare-able

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["test-apps", "testing-tools"]
 travis-ci = { repository = "RazrFalcon/roxmltree" }
 
 [dependencies]
-xmlparser = "0.13.1"
+xmlparser = "0.13.2"
 
 [dev-dependencies]
 pretty_assertions = "0.5"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -28,7 +28,7 @@ use crate::{
 
 
 /// A list of all possible errors.
-#[derive(Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Error {
     /// The `xmlns:xml` attribute must have an <http://www.w3.org/XML/1998/namespace> URI.
     InvalidXmlPrefixUri(TextPos),


### PR DESCRIPTION
Hello,
I'm an active user of this crate. In my current project I need a way to compare the errors returned from the XML tree parsing. To enable this, I created this PR.

This commit additionally derives the equality-related traits. Therefore errors can now be compared. As this is a auto-derive, no tests were added.

__Note__: this is blocked by https://github.com/RazrFalcon/xmlparser/pull/12, as the underlying `xmlparser::Error` has to have the same traits as well. That PR has to be accepted and the dependency version number has to be increased before merging this.