### PR TITLE
Fix returned lifetime of `Document::descendants()`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl<'input> Document<'input> {
     ///
     /// Shorthand for `doc.root().descendants()`.
     #[inline]
-    pub fn descendants(&self) -> Descendants {
+    pub fn descendants(&self) -> Descendants<'_, 'input> {
         self.root().descendants()
     }
 


### PR DESCRIPTION
Also enable lint `elided_lifetimes_in_paths` (warn).