### PR TITLE
Add function to set allow_dtd in builder style

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -229,6 +229,23 @@ impl Default for ParsingOptions {
     }
 }
 
+impl ParsingOptions {
+    /// Allows DTD parsing if set to `true`. Otherwise, XML with DTD will cause an error.
+    /// Empty DTD block is not an error.
+    ///
+    /// Currently, there is no option to simply skip DTD.
+    /// Mainly because you will get `UnknownEntityReference` error later anyway.
+    ///
+    /// This flag is set to `false` by default for security reasons,
+    /// but `roxmltree` still has checks for billion laughs attack,
+    /// so this is just an extra security measure.
+    ///
+    /// Default: false
+    pub fn allow_dtd(self, allow_dtd: bool) -> Self {
+        self.allow_dtd = allow_dtd;
+        self
+    }
+}
 
 struct AttributeData<'input> {
     prefix: StrSpan<'input>,


### PR DESCRIPTION
Generally, most libraries allow configuring options through functions in the style of `fn value(self, value: ValueType) -> Self`. I have added this to ParsingOptions to make specifying the options more natural - instead of

```rust
let mut options = roxmltree::ParsingOptions::default();
options.allow_dtd = true;
let document = Document::parse_with_options(&document_text, options).unwrap();
```

you can now do
```rust
let document = Document::parse_with_options(
    &document_text,
    roxmltree::ParsingOptions::default()
        .allow_dtd(true)
).unwrap();
```

This builder style would be also useful in the future, if new options are ever added, as they can simply be chained.