### PR TITLE
Add libxml to benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ You can try running the benchmarks yourself by running `cargo bench` in the `ben
 
 - Since all libraries have a different XML support, benchmarking is a bit pointless.
 - Tree crates may use different *xml-rs* crate versions.
-- We do not bench the libxml2, because `xmlReadFile()` will parse only an XML structure,
-  without attributes normalization and stuff. So it's hard to compare.
-  And we have to use a separate benchmark utility.
+- We bench *libxml2* using the *[rust-libxml]* wrapper crate 
 - *quick-xml* is faster than *xmlparser* because it's more forgiving for the input,
   while *xmlparser* is very strict and does a lot of checks, which are expensive.
   So performance difference is mainly due to validation.
@@ -157,6 +155,7 @@ You can try running the benchmarks yourself by running `cargo bench` in the `ben
 [xml-rs]: https://crates.io/crates/xml-rs
 [quick-xml]: https://crates.io/crates/quick-xml
 [xmlparser]: https://crates.io/crates/xmlparser
+[rust-libxml]: https://github.com/KWARC/rust-libxml
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -88,20 +88,23 @@ There is also `elementtree` and `treexml` crates, but they are abandoned for a l
 ### Parsing
 
 ```text
-test large_roxmltree     ... bench:   3,123,941 ns/iter (+/- 19,992)
-test large_minidom       ... bench:   4,969,218 ns/iter (+/- 163,727)
-test large_sdx_document  ... bench:   7,266,856 ns/iter (+/- 26,998)
-test large_xmltree       ... bench:  21,354,608 ns/iter (+/- 136,311)
+test large_roxmltree     ... bench:   1,553,308 ns/iter (+/- 58,306)
+test large_libxml        ... bench:   1,933,786 ns/iter (+/- 58,435)
+test large_sdx_document  ... bench:   3,469,016 ns/iter (+/- 227,326)
+test large_minidom       ... bench:   3,532,325 ns/iter (+/- 108,046)
+test large_xmltree       ... bench:  12,009,212 ns/iter (+/- 749,100)
 
-test medium_roxmltree    ... bench:     547,522 ns/iter (+/- 5,956)
-test medium_minidom      ... bench:   1,223,620 ns/iter (+/- 16,180)
-test medium_sdx_document ... bench:   2,470,063 ns/iter (+/- 24,159)
-test medium_xmltree      ... bench:   8,083,860 ns/iter (+/- 25,363)
+test medium_roxmltree    ... bench:     419,176 ns/iter (+/- 18,119)
+test medium_libxml       ... bench:     692,290 ns/iter (+/- 155,278)
+test medium_minidom      ... bench:     781,737 ns/iter (+/- 33,125)
+test medium_sdx_document ... bench:   1,237,014 ns/iter (+/- 39,868)
+test medium_xmltree      ... bench:   3,898,475 ns/iter (+/- 213,596)
 
-test tiny_roxmltree      ... bench:       4,170 ns/iter (+/- 41)
-test tiny_minidom        ... bench:       7,495 ns/iter (+/- 81)
-test tiny_sdx_document   ... bench:      17,411 ns/iter (+/- 203)
-test tiny_xmltree        ... bench:      29,522 ns/iter (+/- 223)
+test tiny_roxmltree      ... bench:       2,165 ns/iter (+/- 25)
+test tiny_minidom        ... bench:       5,645 ns/iter (+/- 82)
+test tiny_libxml         ... bench:       6,446 ns/iter (+/- 163)
+test tiny_sdx_document   ... bench:       8,678 ns/iter (+/- 739)
+test tiny_xmltree        ... bench:      15,711 ns/iter (+/- 278)
 ```
 
 *roxmltree* uses [xmlparser] internally,
@@ -111,29 +114,29 @@ and *minidom* uses [quick-xml].
 Here is a comparison between *xmlparser*, *xml-rs* and *quick-xml*:
 
 ```text
-test large_quick_xml     ... bench:   1,286,273 ns/iter (+/- 27,174)
-test large_xmlparser     ... bench:   1,742,202 ns/iter (+/- 11,616)
-test large_xmlrs         ... bench:  19,615,797 ns/iter (+/- 105,848)
+test large_xmlparser     ... bench:     732,620 ns/iter (+/- 6,615)
+test large_quick_xml     ... bench:     953,197 ns/iter (+/- 42,547)
+test large_xmlrs         ... bench:   9,932,179 ns/iter (+/- 271,766)
 
-test medium_quick_xml    ... bench:     248,169 ns/iter (+/- 3,885)
-test medium_xmlparser    ... bench:     386,658 ns/iter (+/- 1,721)
-test medium_xmlrs        ... bench:   7,387,753 ns/iter (+/- 18,668)
+test medium_quick_xml    ... bench:     222,990 ns/iter (+/- 21,897)
+test medium_xmlparser    ... bench:     252,363 ns/iter (+/- 2,298)
+test medium_xmlrs        ... bench:   3,617,399 ns/iter (+/- 91,085)
 
-test tiny_quick_xml      ... bench:       2,382 ns/iter (+/- 29)
-test tiny_xmlparser      ... bench:       2,788 ns/iter (+/- 20)
-test tiny_xmlrs          ... bench:      27,619 ns/iter (+/- 262)
+test tiny_xmlparser      ... bench:       1,040 ns/iter (+/- 7)
+test tiny_quick_xml      ... bench:       1,634 ns/iter (+/- 25)
+test tiny_xmlrs          ... bench:      14,095 ns/iter (+/- 217)
 ```
 
 ### Iteration
 
 ```text
-test xmltree_iter_descendants_expensive     ... bench:     436,684 ns/iter (+/- 7,851)
-test roxmltree_iter_descendants_expensive   ... bench:     470,459 ns/iter (+/- 6,233)
-test minidom_iter_descendants_expensive     ... bench:     785,847 ns/iter (+/- 51,495)
+test xmltree_iter_descendants_expensive     ... bench:     343,790 ns/iter (+/- 2,767)
+test roxmltree_iter_descendants_expensive   ... bench:     562,800 ns/iter (+/- 7,487)
+test minidom_iter_descendants_expensive     ... bench:     662,709 ns/iter (+/- 2,380)
 
-test roxmltree_iter_descendants_inexpensive ... bench:      36,759 ns/iter (+/- 684)
-test xmltree_iter_descendants_inexpensive   ... bench:     168,541 ns/iter (+/- 1,885)
-test minidom_iter_descendants_inexpensive   ... bench:     215,615 ns/iter (+/- 38,101)
+test roxmltree_iter_descendants_inexpensive ... bench:      25,648 ns/iter (+/- 949)
+test xmltree_iter_descendants_inexpensive   ... bench:      76,779 ns/iter (+/- 1,026)
+test minidom_iter_descendants_inexpensive   ... bench:     114,691 ns/iter (+/- 1,803)
 ```
 
 Where expensive refers to the matching done on each element. In these
@@ -143,11 +146,12 @@ particular name.
 
 ### Notes
 
+The benchmarks were taken on a 2021 MacBook Pro with the Apple M1 Pro chip with 16GB of RAM.
 You can try running the benchmarks yourself by running `cargo bench` in the `benches` dir.
 
 - Since all libraries have a different XML support, benchmarking is a bit pointless.
 - Tree crates may use different *xml-rs* crate versions.
-- We bench *libxml2* using the *[rust-libxml]* wrapper crate 
+- We bench *libxml2* using the *[rust-libxml]* wrapper crate
 - *quick-xml* is faster than *xmlparser* because it's more forgiving for the input,
   while *xmlparser* is very strict and does a lot of checks, which are expensive.
   So performance difference is mainly due to validation.

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -4,6 +4,19 @@ version = "0.1.0"
 edition = "2018"
 workspace = ".."
 
+[features]
+## Enables support for rust-libxml for benchmarks. rust-libxml requires native 
+## dependencies on the your local machine to run. 
+##
+## To run the benchmarks with the libxml feature on, first install the required
+## dependencies outlined in https://github.com/kwarc/rust-libxml/
+## You can run the benchmarks with the libxml feature on with:
+##
+## ```
+## $ cargo bench --features=libxml
+## ```
+libxml = ["dep:libxml"]
+
 [dependencies]
 bencher = "0.1"
 minidom = "0.12"
@@ -13,7 +26,7 @@ sxd-document = "0.3"
 xml-rs = "0.8"
 xmlparser = "0.13"
 xmltree = "0.10"
-libxml = "0.3.1"
+libxml = { version = "0.3.1", optional = true }
 
 [[bench]]
 name = "benchmark"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -4,19 +4,6 @@ version = "0.1.0"
 edition = "2018"
 workspace = ".."
 
-[features]
-## Enables support for rust-libxml for benchmarks. rust-libxml requires native 
-## dependencies on the your local machine to run. 
-##
-## To run the benchmarks with the libxml feature on, first install the required
-## dependencies outlined in https://github.com/kwarc/rust-libxml/
-## You can run the benchmarks with the libxml feature on with:
-##
-## ```
-## $ cargo bench --features=libxml
-## ```
-libxml = ["dep:libxml"]
-
 [dependencies]
 bencher = "0.1"
 minidom = "0.12"
@@ -26,6 +13,16 @@ sxd-document = "0.3"
 xml-rs = "0.8"
 xmlparser = "0.13"
 xmltree = "0.10"
+
+# Enables support for libxml for benchmarks. libxml requires native dependencies
+# on your local machine to run, so make sure to have it installed.
+# See: https://github.com/kwarc/rust-libxml/
+#
+# You can run the benchmarks with the libxml feature on with:
+#
+# ```
+# $ cargo bench --features=libxml
+# ```
 libxml = { version = "0.3.1", optional = true }
 
 [[bench]]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,6 +13,7 @@ sxd-document = "0.3"
 xml-rs = "0.8"
 xmlparser = "0.13"
 xmltree = "0.10"
+libxml = "0.3.1"
 
 [[bench]]
 name = "benchmark"

--- a/benches/xml.rs
+++ b/benches/xml.rs
@@ -163,6 +163,7 @@ fn large_minidom(bencher: &mut Bencher) {
     })
 }
 
+#[cfg(feature = "libxml")]
 fn tiny_libxml(bencher: &mut Bencher) {
     let text = std::fs::read_to_string("fonts.conf").unwrap();
     bencher.iter(|| {
@@ -172,6 +173,7 @@ fn tiny_libxml(bencher: &mut Bencher) {
     })
 }
 
+#[cfg(feature = "libxml")]
 fn medium_libxml(bencher: &mut Bencher) {
     let text = std::fs::read_to_string("medium.svg").unwrap();
     bencher.iter(|| {
@@ -181,6 +183,7 @@ fn medium_libxml(bencher: &mut Bencher) {
     })
 }
 
+#[cfg(feature = "libxml")]
 fn large_libxml(bencher: &mut Bencher) {
     let text = std::fs::read_to_string("large.plist").unwrap();
     bencher.iter(|| {
@@ -238,7 +241,7 @@ fn minidom_iter_descendants_inexpensive(bencher: &mut Bencher) {
         let mut count = 0;
         let mut stack: Vec<&minidom::Element> = vec![&root];
         while let Some(node) = stack.pop() {
-            if node.name() == "string" { count += 1}
+            if node.name() == "string" { count += 1 }
             stack.append(&mut node.children().collect::<Vec<_>>());
         }
         assert!(count == 3273);
@@ -266,7 +269,7 @@ fn xmltree_iter_descendants_inexpensive(bencher: &mut Bencher) {
         let mut count = 0;
         let mut stack: Vec<&xmltree::Element> = vec![&root];
         while let Some(node) = stack.pop() {
-            if node.name == "string" { count += 1}
+            if node.name == "string" { count += 1 }
             stack.append(&mut node
                 .children
                 .iter()
@@ -324,7 +327,23 @@ benchmark_group!(minidom, tiny_minidom, medium_minidom, large_minidom);
 benchmark_group!(xmlparser, tiny_xmlparser, medium_xmlparser, large_xmlparser);
 benchmark_group!(xmlrs, tiny_xmlrs, medium_xmlrs, large_xmlrs);
 benchmark_group!(quick_xml, tiny_quick_xml, medium_quick_xml, large_quick_xml);
+#[cfg(feature = "libxml")]
 benchmark_group!(libxml, tiny_libxml, medium_libxml, large_libxml);
+
+#[cfg(not(feature = "libxml"))]
+benchmark_main!(
+    roxmltree,
+    xmltree,
+    sdx,
+    minidom,
+    xmlparser,
+    xmlrs,
+    quick_xml,
+    roxmltree_iter,
+    minidom_iter,
+    xmltree_iter);
+
+#[cfg(feature = "libxml")]
 benchmark_main!(
     roxmltree,
     xmltree,

--- a/benches/xml.rs
+++ b/benches/xml.rs
@@ -163,6 +163,33 @@ fn large_minidom(bencher: &mut Bencher) {
     })
 }
 
+fn tiny_libxml(bencher: &mut Bencher) {
+    let text = std::fs::read_to_string("fonts.conf").unwrap();
+    bencher.iter(|| {
+        libxml::parser::Parser::default()
+            .parse_string(&text)
+            .unwrap()
+    })
+}
+
+fn medium_libxml(bencher: &mut Bencher) {
+    let text = std::fs::read_to_string("medium.svg").unwrap();
+    bencher.iter(|| {
+        libxml::parser::Parser::default()
+            .parse_string(&text)
+            .unwrap()
+    })
+}
+
+fn large_libxml(bencher: &mut Bencher) {
+    let text = std::fs::read_to_string("large.plist").unwrap();
+    bencher.iter(|| {
+        libxml::parser::Parser::default()
+            .parse_string(&text)
+            .unwrap()
+    })
+}
+
 fn roxmltree_iter_descendants_inexpensive(bencher: &mut Bencher) {
     let text = std::fs::read_to_string("large.plist").unwrap();
     let doc = roxmltree::Document::parse(&text).unwrap();
@@ -297,6 +324,7 @@ benchmark_group!(minidom, tiny_minidom, medium_minidom, large_minidom);
 benchmark_group!(xmlparser, tiny_xmlparser, medium_xmlparser, large_xmlparser);
 benchmark_group!(xmlrs, tiny_xmlrs, medium_xmlrs, large_xmlrs);
 benchmark_group!(quick_xml, tiny_quick_xml, medium_quick_xml, large_quick_xml);
+benchmark_group!(libxml, tiny_libxml, medium_libxml, large_libxml);
 benchmark_main!(
     roxmltree,
     xmltree,
@@ -305,6 +333,7 @@ benchmark_main!(
     xmlparser,
     xmlrs,
     quick_xml,
+    libxml,
     roxmltree_iter,
     minidom_iter,
     xmltree_iter);


### PR DESCRIPTION
This PR adds benchmarks for [libxml](https://docs.rs/libxml/latest/libxml/), a Rust wrapper for libxml2, to the benches directory.

I noticed libxml being brought up in the comparison chart in this repo's README, and thought that it wouldn't hurt to add benchmark support for it as well.

The output for the benchmarks with the added support for libxml is, on my machine, as follows.
```
running 31 tests
test large_libxml                           ... bench:   3,039,151 ns/iter (+/- 526,303)
test large_minidom                          ... bench:   4,676,869 ns/iter (+/- 874,824)
test large_quick_xml                        ... bench:   1,295,351 ns/iter (+/- 70,644)
test large_roxmltree                        ... bench:   3,770,715 ns/iter (+/- 143,998)
test large_sdx_document                     ... bench:   5,275,995 ns/iter (+/- 487,982)
test large_xmlparser                        ... bench:   1,443,349 ns/iter (+/- 39,438)
test large_xmlrs                            ... bench:  15,298,528 ns/iter (+/- 2,173,173)
test large_xmltree                          ... bench:  16,080,618 ns/iter (+/- 2,104,208)
test medium_libxml                          ... bench:   1,073,825 ns/iter (+/- 72,811)
test medium_minidom                         ... bench:   1,188,021 ns/iter (+/- 89,335)
test medium_quick_xml                       ... bench:     255,621 ns/iter (+/- 1,748)
test medium_roxmltree                       ... bench:     726,254 ns/iter (+/- 14,171)
test medium_sdx_document                    ... bench:   1,837,580 ns/iter (+/- 63,458)
test medium_xmlparser                       ... bench:     378,369 ns/iter (+/- 10,106)
test medium_xmlrs                           ... bench:   5,690,207 ns/iter (+/- 248,119)
test medium_xmltree                         ... bench:   6,429,148 ns/iter (+/- 214,098)
test minidom_iter_descendants_expensive     ... bench:     745,237 ns/iter (+/- 28,585)
test minidom_iter_descendants_inexpensive   ... bench:     167,407 ns/iter (+/- 8,938)
test roxmltree_iter_children                ... bench:       2,537 ns/iter (+/- 44)
test roxmltree_iter_descendants_expensive   ... bench:     545,544 ns/iter (+/- 9,825)
test roxmltree_iter_descendants_inexpensive ... bench:      43,797 ns/iter (+/- 1,364)
test tiny_libxml                            ... bench:      10,412 ns/iter (+/- 10,549)
test tiny_minidom                           ... bench:       8,330 ns/iter (+/- 1,410)
test tiny_quick_xml                         ... bench:       2,966 ns/iter (+/- 798)
test tiny_roxmltree                         ... bench:       6,252 ns/iter (+/- 237)
test tiny_sdx_document                      ... bench:      17,363 ns/iter (+/- 5,829)
test tiny_xmlparser                         ... bench:       3,082 ns/iter (+/- 983)
test tiny_xmlrs                             ... bench:      29,442 ns/iter (+/- 4,401)
test tiny_xmltree                           ... bench:      31,651 ns/iter (+/- 4,313)
test xmltree_iter_descendants_expensive     ... bench:     468,561 ns/iter (+/- 22,069)
test xmltree_iter_descendants_inexpensive   ... bench:     145,578 ns/iter (+/- 38,287)
```