### PR TITLE
RFC: Track parent prefixes using a stack to drop ExpandedNameOwned::prefix 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,7 +575,6 @@ impl<'input> Deref for Namespaces<'input> {
 #[derive(Clone, PartialEq)]
 struct ExpandedNameOwned<'input> {
     ns: Option<Cow<'input, str>>,
-    prefix: &'input str, // Used only for closing tags matching during parsing.
     name: &'input str,
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -685,6 +685,8 @@ fn process_element<'input>(
             let local = local.as_str();
 
             let parent_node = &mut doc.nodes[parent_id.get_usize()];
+            // should never panic as we start with the single prefix of the
+            // root node and always push another one when changing the parent
             let parent_prefix = *pd.parent_prefixes.last().unwrap();
 
             parent_node.range.end = token_span.end() as u32;


### PR DESCRIPTION
This my stab at the item mentioned in #63 and I have to admit that I am bit out of my depth here meaning that I wrote this based on reading the code and running the tests, not based on a actually understanding the XML processing parts. This is why I added the redundant tracking first, asserting that it would be equivalent to the in-node data and only in the last commit actually removed the `ExpandedOwnedName::prefix` field.

With this in mind, I am sorry if this is completely bogus, especially the second commit as I am unable to argue why there should be no branching, I just did never observe this during the tests.