### PR TITLE
Hide token ranges w.r.t. original input behind feature flag.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,10 @@ jobs:
         override: true
 
     - name: Run tests
-      run: cargo test --all-features
+      run: cargo test
+
+    - name: Run tests without token-ranges
+      run: cargo test --no-default-features --features std
 
     - name: Build without std
       run: cargo build --no-default-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         override: true
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features
 
     - name: Build without std
       run: cargo build --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ exclude = ["test-apps", "testing-tools"]
 xmlparser = "0.13.5"
 
 [features]
-default = ["std"]
+default = ["std", "token-ranges"]
 std = []
 token-ranges = []
-
-[package.metadata.docs.rs]
-features = ["token-ranges"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ xmlparser = "0.13.5"
 [features]
 default = ["std"]
 std = []
+token-ranges = []
+
+[package.metadata.docs.rs]
+features = ["token-ranges"]

--- a/examples/print_pos.rs
+++ b/examples/print_pos.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "token-ranges")]
 fn main() {
     let args: Vec<_> = std::env::args().collect();
 
@@ -23,3 +24,6 @@ fn main() {
         }
     }
 }
+
+#[cfg(not(feature = "token-ranges"))]
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ type Range = core::ops::Range<usize>;
 pub struct Document<'input> {
     /// An original data.
     ///
-    /// Required for `text_pos` methods.
+    /// Required for `text_pos_at` methods.
     text: &'input str,
     nodes: Vec<NodeData<'input>>,
     attrs: Vec<Attribute<'input>>,
@@ -384,6 +384,7 @@ struct NodeData<'input> {
     next_subtree: Option<NodeId>,
     last_child: Option<NodeId>,
     kind: NodeKind<'input>,
+    #[cfg(feature = "token-ranges")]
     range: ShortRange,
 }
 
@@ -393,7 +394,9 @@ struct NodeData<'input> {
 pub struct Attribute<'input> {
     name: ExpandedNameOwned<'input>,
     value: Cow<'input, str>,
+    #[cfg(feature = "token-ranges")]
     range: ShortRange,
+    #[cfg(feature = "token-ranges")]
     value_range: ShortRange,
 }
 
@@ -459,6 +462,7 @@ impl<'input> Attribute<'input> {
     /// ```
     ///
     /// [Document::text_pos_at]: struct.Document.html#method.text_pos_at
+    #[cfg(feature = "token-ranges")]
     #[inline]
     pub fn range(&self) -> Range {
         self.range.to_urange()
@@ -474,6 +478,7 @@ impl<'input> Attribute<'input> {
     /// ```
     ///
     /// [Document::text_pos_at]: struct.Document.html#method.text_pos_at
+    #[cfg(feature = "token-ranges")]
     #[inline]
     pub fn value_range(&self) -> Range {
         self.value_range.to_urange()
@@ -1207,6 +1212,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     }
 
     /// Returns node's range in bytes in the original document.
+    #[cfg(feature = "token-ranges")]
     #[inline]
     pub fn range(&self) -> Range {
         self.d.range.to_urange()

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -119,6 +119,7 @@ fn lookup_namespace_uri() {
     assert_eq!(node.lookup_namespace_uri(Some("n2")), None);
 }
 
+#[cfg(feature = "token-ranges")]
 #[test]
 fn text_pos_01() {
     let data = "\
@@ -154,6 +155,7 @@ fn text_pos_01() {
     assert_eq!(doc.text_pos_at(text.range().start), TextPos::new(3, 8));
 }
 
+#[cfg(feature = "token-ranges")]
 #[test]
 fn text_pos_02() {
     let data = "<n1:e xmlns:n1='http://www.w3.org' n1:a='b'/>";
@@ -169,6 +171,7 @@ fn text_pos_02() {
     }
 }
 
+#[cfg(feature = "token-ranges")]
 #[test]
 fn text_pos_03() {
     let data = "\


### PR DESCRIPTION
Few things I am unsure about:

- Did I find all of them and is a compile-time feature what was intended by #63?
- Should this be a default (would be mostly backwards compatible) or non-default (ecosystem automatically picks up gains) feature?
- Should `Document::text_pos_at`, `Document::input_text` and `Document::input` also be gated behind this?
- The unit tests currently work only with the feature enabled. So maybe a default feature after all or rework the tests to assert ranges only if enabled?