### PR TITLE
RFC: Use empty namespace as niche to avoid space overhead of Option in ExpandedNameOwned.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,7 +415,7 @@ impl<'input> Attribute<'input> {
     /// ```
     #[inline]
     pub fn namespace(&self) -> Option<&str> {
-        self.name.ns.as_ref().map(Cow::as_ref)
+        if !self.name.ns.is_empty() { Some(&*self.name.ns) } else { None }
     }
 
     /// Returns attribute's name.
@@ -576,10 +576,9 @@ impl<'input> Deref for Namespaces<'input> {
     }
 }
 
-
 #[derive(Clone, PartialEq)]
 struct ExpandedNameOwned<'input> {
-    ns: Option<Cow<'input, str>>,
+    ns: Cow<'input, str>,
     name: &'input str,
 }
 
@@ -587,7 +586,7 @@ impl<'a, 'input> ExpandedNameOwned<'input> {
     #[inline]
     fn as_ref(&'a self) -> ExpandedName<'a, 'input> {
         ExpandedName {
-            uri: self.ns.as_ref().map(Cow::as_ref),
+            uri: if !self.ns.is_empty() { Some(&*self.ns) } else { None },
             name: self.name,
         }
     }
@@ -595,9 +594,10 @@ impl<'a, 'input> ExpandedNameOwned<'input> {
 
 impl<'input> fmt::Debug for ExpandedNameOwned<'input> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self.ns {
-            Some(ref ns) => write!(f, "{{{}}}{}", ns.as_ref(), self.name),
-            None => write!(f, "{}", self.name),
+        if !self.ns.is_empty() {
+            write!(f, "{{{}}}{}", self.ns, self.name)
+        } else {
+            write!(f, "{}", self.name)
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -787,11 +787,11 @@ fn resolve_attributes<'input>(
         let ns = if attr.prefix.as_str() == "xml" {
             // The prefix 'xml' is by definition bound to the namespace name
             // http://www.w3.org/XML/1998/namespace.
-            Some(Cow::Borrowed(NS_XML_URI))
+            Cow::Borrowed(NS_XML_URI)
         } else if attr.prefix.is_empty() {
             // 'The namespace name for an unprefixed attribute name
             // always has no value.'
-            None
+            Cow::Borrowed("")
         } else {
             get_ns_by_prefix(doc, namespaces, attr.prefix)?
         };
@@ -1064,7 +1064,7 @@ fn get_ns_by_prefix<'input>(
     doc: &Document<'input>,
     range: ShortRange,
     prefix: StrSpan,
-) -> Result<Option<Cow<'input, str>>, Error> {
+) -> Result<Cow<'input, str>, Error> {
     // Prefix CAN be empty when the default namespace was defined.
     //
     // Example:
@@ -1076,7 +1076,7 @@ fn get_ns_by_prefix<'input>(
         .map(|ns| ns.uri.clone());
 
     match uri {
-        Some(v) => Ok(Some(v)),
+        Some(v) => Ok(v),
         None => {
             if !prefix.is_empty() {
                 // If an URI was not found and prefix IS NOT empty than
@@ -1092,7 +1092,7 @@ fn get_ns_by_prefix<'input>(
                 //
                 // Example:
                 // <e a='b'/>
-                Ok(None)
+                Ok(Cow::Borrowed(""))
             }
         }
     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -84,11 +84,11 @@ fn empty_ns() {
     let doc = Document::parse(data).unwrap();
     let p = doc.root_element();
 
-    assert_eq!(p.attribute(("", "attr")), Some("val"));
-    assert_eq!(p.has_attribute(("", "attr")), true);
+    assert_eq!(p.attribute("attr"), Some("val"));
+    assert_eq!(p.has_attribute("attr"), true);
 
-    assert_eq!(p.attribute("attr"), None);
-    assert_eq!(p.has_attribute("attr"), false);
+    assert_eq!(p.attribute(("", "attr")), None);
+    assert_eq!(p.has_attribute(("", "attr")), false);
 }
 
 #[test]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -78,6 +78,20 @@ fn api_01() {
 }
 
 #[test]
+fn empty_ns() {
+    let data = "<e a:attr='val' xmlns:a=''/>";
+
+    let doc = Document::parse(data).unwrap();
+    let p = doc.root_element();
+
+    assert_eq!(p.attribute(("", "attr")), Some("val"));
+    assert_eq!(p.has_attribute(("", "attr")), true);
+
+    assert_eq!(p.attribute("attr"), None);
+    assert_eq!(p.has_attribute("attr"), false);
+}
+
+#[test]
 fn get_pi() {
     let data = "\
 <?target value?>


### PR DESCRIPTION
If XML does allow empty namespaces, then this optimization is not valid. Otherwise, it reduces the size of `ExpandedNameOwned` from 48 to 40 bytes on amd64, i.e. a 16% reduction.