### PR TITLE
Follow-up: Use indexes for Node and Attribute Namespaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ extern crate alloc;
 extern crate std;
 
 use alloc::borrow::Cow;
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::fmt;
@@ -128,6 +127,7 @@ impl<'input> Document<'input> {
 
     fn get_attribute<'a>(&'a self, idx: usize) -> Attribute<'a, 'input> {
         Attribute {
+            doc: self,
             d: &self.attrs[idx],
         }
     }
@@ -330,53 +330,6 @@ impl ShortRange {
     }
 }
 
-/// A custom variant of `Cow<'a, str>` that
-/// keeps a niche available and sheds excess capacity.
-///
-/// This variant stores `Box<str>` instead of `String`
-/// which is more appropriate for a space-conscious
-/// read-only data structure as
-///
-/// 1. it keeps a niche available so that for example
-///
-///    ```rust,ignore
-///    assert_eq!(
-///        size_of::<CowStr<'static>>(),
-///        size_of::<Option<CowStr<'static>>>(),
-///    );
-///    ```
-///
-///    holds and
-///
-/// 2. it sheds any excess capacity that was allocated
-///    when an owned string had to be constructed thereby
-///    keeping only the amount of memory around that is
-///    required to store the string.
-#[derive(Clone, PartialEq)]
-enum CowStr<'a> {
-    Borrowed(&'a str),
-    Owned(Box<str>),
-}
-
-impl<'a> From<Cow<'a, str>> for CowStr<'a> {
-    fn from(v: Cow<'a, str>) -> CowStr<'a> {
-        match v {
-            Cow::Borrowed(v) => CowStr::Borrowed(v),
-            Cow::Owned(v) => CowStr::Owned(v.into()),
-        }
-    }
-}
-
-impl<'a> AsRef<str> for CowStr<'a> {
-    fn as_ref(&self) -> &str {
-        match self {
-            CowStr::Borrowed(v) => v,
-            CowStr::Owned(ref v) => v,
-        }
-    }
-}
-
-
 /// A node ID stored as `u32`.
 ///
 /// An index into a `Tree`-internal `Vec`.
@@ -455,7 +408,7 @@ struct NodeData<'input> {
 
 #[derive(Clone)]
 struct AttributeData<'input> {
-    name: ExpandedNameOwned<'input>,
+    name: NamespacedName<'input>,
     value: Cow<'input, str>,
     #[cfg(feature = "token-ranges")]
     range: ShortRange,
@@ -466,6 +419,7 @@ struct AttributeData<'input> {
 /// An attribute.
 #[derive(Copy, Clone)]
 pub struct Attribute<'doc, 'input: 'doc> {
+    doc: &'doc Document<'input>,
     d: &'doc AttributeData<'input>,
 }
 
@@ -484,7 +438,7 @@ impl<'doc, 'input> Attribute<'doc, 'input> {
     /// ```
     #[inline]
     pub fn namespace(&self) -> Option<&'doc str> {
-        self.d.name.ns.as_ref().map(CowStr::as_ref)
+        self.d.name.namespace(self.doc).map(Namespace::uri)
     }
 
     /// Returns attribute's name.
@@ -501,7 +455,7 @@ impl<'doc, 'input> Attribute<'doc, 'input> {
     /// ```
     #[inline]
     pub fn name(&self) -> &'doc str {
-        self.d.name.name
+        self.d.name.local_name
     }
 
     /// Returns attribute's value.
@@ -557,14 +511,14 @@ impl<'doc, 'input> Attribute<'doc, 'input> {
 impl PartialEq for Attribute<'_, '_> {
     #[inline]
     fn eq(&self, other: &Attribute<'_, '_>) -> bool {
-        self.d.name == other.d.name && self.d.value == other.d.value
+        self.d.name.as_expanded_name(self.doc) == other.d.name.as_expanded_name(self.doc) && self.d.value == other.d.value
     }
 }
 
 impl fmt::Debug for Attribute<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "Attribute {{ name: {:?}, value: {:?} }}",
-               self.d.name, self.d.value)
+               self.d.name.as_expanded_name(self.doc), self.d.value)
     }
 }
 
@@ -645,33 +599,7 @@ impl<'input> Deref for Namespaces<'input> {
     }
 }
 
-
-#[derive(Clone, PartialEq)]
-struct ExpandedNameOwned<'input> {
-    ns: Option<CowStr<'input>>,
-    name: &'input str,
-}
-
-impl<'a, 'input> ExpandedNameOwned<'input> {
-    #[inline]
-    fn as_ref(&'a self) -> ExpandedName<'a, 'input> {
-        ExpandedName {
-            uri: self.ns.as_ref().map(CowStr::as_ref),
-            name: self.name,
-        }
-    }
-}
-
-impl<'input> fmt::Debug for ExpandedNameOwned<'input> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self.ns {
-            Some(ref ns) => write!(f, "{{{}}}{}", ns.as_ref(), self.name),
-            None => write!(f, "{}", self.name),
-        }
-    }
-}
-
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 struct NamespacedName<'input> {
     namespace_idx: Option<u32>,
     local_name: &'input str
@@ -1027,7 +955,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
         let name = name.into();
         self.attribute_data()
             .iter()
-            .find(|a| a.name.as_ref() == name)
+            .find(|a| a.name.as_expanded_name(self.doc) == name)
             .map(|a| a.value.as_ref())
     }
 
@@ -1041,7 +969,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
         N: Into<ExpandedName<'n, 'm>>,
     {
         let name = name.into();
-        self.attributes().find(|a| a.d.name.as_ref() == name)
+        self.attributes().find(|a| a.d.name.as_expanded_name(self.doc) == name)
     }
 
     /// Checks that element has a specified attribute.
@@ -1066,7 +994,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
         let name = name.into();
         self.attribute_data()
             .iter()
-            .any(|a| a.name.as_ref() == name)
+            .any(|a| a.name.as_expanded_name(self.doc) == name)
     }
 
     /// Returns element's attributes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,8 +216,8 @@ impl<'input> fmt::Debug for Document<'input> {
 
         fn print_into_iter<
             T: fmt::Debug,
-            E: Iterator<Item=T> + ExactSizeIterator,
-            I: IntoIterator<IntoIter=E>
+            E: ExactSizeIterator<Item=T>,
+            I: IntoIterator<Item=T, IntoIter=E>
         >(
             prefix: &str,
             data: I,
@@ -1299,11 +1299,13 @@ impl<'a, 'input> Iterator for Attributes<'a, 'input> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        (self.current < self.until).then(|| {
+        if self.current < self.until {
             let next = self.doc.get_attribute(self.current);
             self.current += 1;
-            next
-        })
+            Some(next)
+        } else {
+            None
+        }
     }
 
     #[inline]
@@ -1322,11 +1324,13 @@ impl<'a, 'input> Iterator for Attributes<'a, 'input> {
 impl<'a, 'input> DoubleEndedIterator for Attributes<'a, 'input> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        (self.current < self.until).then(|| {
+        if self.current < self.until {
             let next = self.doc.get_attribute(self.until);
             self.until -= 1;
-            next
-        })
+            Some(next)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -23,7 +23,7 @@ use crate::{
     NodeKind,
     PI,
     ShortRange,
-    NamespacedName,
+    ExpandedNameIndexed,
 };
 
 
@@ -683,7 +683,7 @@ fn process_element<'input>(
             let tag_ns_idx = get_ns_idx_by_prefix(doc, namespaces, tag_name.prefix)?;
             let new_element_id = doc.append(*parent_id,
                 NodeKind::Element {
-                    tag_name: NamespacedName {
+                    tag_name: ExpandedNameIndexed {
                         namespace_idx: tag_ns_idx,
                         local_name: tag_name.name.as_str(),
                     },
@@ -733,7 +733,7 @@ fn process_element<'input>(
             let tag_ns_idx = get_ns_idx_by_prefix(doc, namespaces, tag_name.prefix)?;
             *parent_id = doc.append(*parent_id,
                 NodeKind::Element {
-                    tag_name: NamespacedName {
+                    tag_name: ExpandedNameIndexed {
                         namespace_idx: tag_ns_idx,
                         local_name: tag_name.name.as_str(),
                     },
@@ -796,7 +796,7 @@ fn resolve_attributes<'input>(
             get_ns_idx_by_prefix(doc, namespaces, attr.prefix)?
         };
 
-        let attr_name = NamespacedName { namespace_idx, local_name: attr.local.as_str() };
+        let attr_name = ExpandedNameIndexed { namespace_idx, local_name: attr.local.as_str() };
 
         // Check for duplicated attributes.
         if doc.attrs[start_idx..].iter().any(|attr| attr.name.as_expanded_name(doc) == attr_name.as_expanded_name(doc)) {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,6 +25,7 @@ use crate::{
     PI,
     ShortRange,
     CowStr,
+    NamespacedName,
 };
 
 
@@ -681,12 +682,12 @@ fn process_element<'input>(
 
     match end_token {
         xmlparser::ElementEnd::Empty => {
-            let tag_ns_uri = get_ns_by_prefix(doc, namespaces, tag_name.prefix)?;
+            let tag_ns_idx = get_ns_idx_by_prefix(doc, namespaces, tag_name.prefix)?;
             let new_element_id = doc.append(*parent_id,
                 NodeKind::Element {
-                    tag_name: ExpandedNameOwned {
-                        ns: tag_ns_uri,
-                        name: tag_name.name.as_str(),
+                    tag_name: NamespacedName {
+                        namespace_idx: tag_ns_idx,
+                        local_name: tag_name.name.as_str(),
                     },
                     attributes,
                     namespaces,
@@ -712,9 +713,9 @@ fn process_element<'input>(
             }
 
             if let NodeKind::Element { ref tag_name, .. } = parent_node.kind {
-                if prefix != parent_prefix || local != tag_name.name {
+                if prefix != parent_prefix || local != tag_name.local_name {
                     return Err(Error::UnexpectedCloseTag {
-                        expected: gen_qname_string(parent_prefix, tag_name.name),
+                        expected: gen_qname_string(parent_prefix, tag_name.local_name),
                         actual: gen_qname_string(prefix, local),
                         pos: err_pos_from_span(doc.text, token_span),
                     });
@@ -731,12 +732,12 @@ fn process_element<'input>(
             }
         }
         xmlparser::ElementEnd::Open => {
-            let tag_ns_uri = get_ns_by_prefix(doc, namespaces, tag_name.prefix)?;
+            let tag_ns_idx = get_ns_idx_by_prefix(doc, namespaces, tag_name.prefix)?;
             *parent_id = doc.append(*parent_id,
                 NodeKind::Element {
-                    tag_name: ExpandedNameOwned {
-                        ns: tag_ns_uri,
-                        name: tag_name.name.as_str(),
+                    tag_name: NamespacedName {
+                        namespace_idx: tag_ns_idx,
+                        local_name: tag_name.name.as_str(),
                     },
                     attributes,
                     namespaces,
@@ -1111,6 +1112,43 @@ fn get_ns_by_prefix<'input>(
             }
         }
     }
+}
+
+fn get_ns_idx_by_prefix<'input>(
+    doc: &Document<'input>,
+    range: ShortRange,
+    prefix: StrSpan,
+) -> Result<Option<u32>, Error> {
+    // Prefix CAN be empty when the default namespace was defined.
+    //
+    // Example:
+    // <e xmlns='http://www.w3.org'/>
+    let prefix_opt = if prefix.is_empty() { None } else { Some(prefix.as_str()) };
+
+    range.to_urange().into_iter()
+        .map(|idx| (idx, &doc.namespaces[idx]))
+        .find(|(_, ns)| ns.name == prefix_opt)
+        .map_or_else(
+            || {
+                if !prefix.is_empty() {
+                    // If an URI was not found and prefix IS NOT empty than
+                    // we have an unknown namespace.
+                    //
+                    // Example:
+                    // <e random:a='b'/>
+                    let pos = err_pos_from_span(doc.text, prefix);
+                    Err(Error::UnknownNamespace(prefix.as_str().to_string(), pos))
+                } else {
+                    // If an URI was not found and prefix IS empty than
+                    // an element or an attribute doesn't have a namespace.
+                    //
+                    // Example:
+                    // <e a='b'/>
+                    Ok(None)
+                }
+            },
+            |(idx, _)| Ok(Some(idx as u32)),
+        )
 }
 
 #[inline]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,7 +15,7 @@ use crate::{
     NS_XML_PREFIX,
     NS_XMLNS_URI,
     XMLNS,
-    Attribute,
+    AttributeData,
     Document,
     ExpandedNameOwned,
     Namespaces,
@@ -234,8 +234,7 @@ impl Default for ParsingOptions {
     }
 }
 
-
-struct AttributeData<'input> {
+struct TempAttributeData<'input> {
     prefix: StrSpan<'input>,
     local: StrSpan<'input>,
     value: Cow<'input, str>,
@@ -334,7 +333,7 @@ struct ParserData<'input> {
     opt: ParsingOptions,
     attrs_start_idx: usize,
     ns_start_idx: usize,
-    tmp_attrs: Vec<AttributeData<'input>>,
+    tmp_attrs: Vec<TempAttributeData<'input>>,
     awaiting_subtree: Vec<NodeId>,
     parent_prefixes: Vec<&'input str>,
     entities: Vec<Entity<'input>>,
@@ -641,7 +640,7 @@ fn process_attribute<'input>(
 
         doc.namespaces.push_ns(None, value);
     } else {
-        pd.tmp_attrs.push(AttributeData {
+        pd.tmp_attrs.push(TempAttributeData {
             prefix, local, value,
             #[cfg(feature = "token-ranges")]
             range,
@@ -676,8 +675,7 @@ fn process_element<'input>(
     let namespaces = resolve_namespaces(pd.ns_start_idx, *parent_id, doc);
     pd.ns_start_idx = doc.namespaces.len();
 
-    let attributes = resolve_attributes(pd.attrs_start_idx, namespaces,
-                                        &mut pd.tmp_attrs, doc)?;
+    let attributes = resolve_attributes(pd, namespaces, doc)?;
     pd.attrs_start_idx = doc.attrs.len();
     pd.tmp_attrs.clear();
 
@@ -776,16 +774,16 @@ fn resolve_namespaces(
 }
 
 fn resolve_attributes<'input>(
-    start_idx: usize,
+    pd: &mut ParserData<'input>,
     namespaces: ShortRange,
-    tmp_attrs: &mut [AttributeData<'input>],
     doc: &mut Document<'input>,
 ) -> Result<ShortRange, Error> {
-    if tmp_attrs.is_empty() {
+    let start_idx = pd.attrs_start_idx;
+    if pd.tmp_attrs.is_empty() {
         return Ok(ShortRange::new(0, 0));
     }
 
-    for attr in tmp_attrs {
+    for attr in &mut pd.tmp_attrs {
         let ns = if attr.prefix.as_str() == NS_XML_PREFIX {
             // The prefix 'xml' is by definition bound to the namespace name
             // http://www.w3.org/XML/1998/namespace.
@@ -806,7 +804,7 @@ fn resolve_attributes<'input>(
             return Err(Error::DuplicatedAttribute(attr.local.to_string(), pos));
         }
 
-        doc.attrs.push(Attribute {
+        doc.attrs.push(AttributeData {
             name: attr_name,
             // Takes a value from a slice without consuming the slice.
             value: core::mem::replace(&mut attr.value, Cow::Borrowed("")),

--- a/tests/ast.rs
+++ b/tests/ast.rs
@@ -97,9 +97,11 @@ fn _to_yaml(doc: &Document, s: &mut String) -> Result<(), fmt::Error> {
                         }
                     }
 
-                    if !child.attributes().is_empty() {
+
+                    let attributes = child.attributes();
+                    if !(attributes.len() == 0) {
                         let mut attrs = Vec::new();
-                        for attr in child.attributes() {
+                        for attr in attributes {
                             match attr.namespace() {
                                 Some(ns) => {
                                     attrs.push((format!("{}@{}", attr.name(), ns), attr.value()));


### PR DESCRIPTION
I am sorry if this is considered invasive, but since I would really like to see #75 in a release and it seemed like only cosmetics were left to do and I had some time on my hands, I went through the open items in #75 and tried to address them by amending or adding commits from the original PR.

As to the requested explanation: Instead of storing the namespace URI itself (possibly owned or as a reference into the input) within tags and attributes, this stores only the index and resolves it on-demand into the (already deduplicated) `Document::namespaces` list using the `Attribute` wrapper around `AttributeData`.

For `greater_londom.osm`, this changes reduces the peak memory consumption from 7.8 GB to 6.7 GB.