### PR TITLE
RFC: Deduplicate namespaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,7 +614,7 @@ impl<'input> Namespaces<'input> {
 
 #[derive(Clone, Copy, Debug)]
 struct ExpandedNameIndexed<'input> {
-    /// Indexes into `Namspaces::tree`
+    /// Indexes into `Namspaces::values`
     namespace_idx: Option<u32>,
     local_name: &'input str,
 }
@@ -623,7 +623,7 @@ impl<'input> ExpandedNameIndexed<'input> {
     #[inline]
     fn namespace<'a>(&self, doc: &'a Document<'input>) -> Option<&'a Namespace<'input>> {
         self.namespace_idx
-            .map(|idx| &doc.namespaces.values[doc.namespaces.tree[idx as usize]])
+            .map(|idx| &doc.namespaces.values[idx as usize])
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,9 +561,9 @@ struct Namespaces<'input> {
     // Deduplicated namespace values used throughout the document
     values: Vec<Namespace<'input>>,
     // Indices into the above in tree order as the document is parsed
-    tree: Vec<usize>,
+    tree: Vec<u16>,
     // Indices into the above sorted by value used for deduplication
-    sorted: Vec<usize>,
+    sorted: Vec<u16>,
 }
 
 impl<'input> Namespaces<'input> {
@@ -574,7 +574,7 @@ impl<'input> Namespaces<'input> {
 
         match self
             .sorted
-            .binary_search_by(|idx| self.values[*idx].cmp(&value))
+            .binary_search_by(|idx| self.values[*idx as usize].cmp(&value))
         {
             Ok(sorted_idx) => {
                 let idx = self.sorted[sorted_idx];
@@ -582,7 +582,7 @@ impl<'input> Namespaces<'input> {
                 self.tree.push(idx);
             }
             Err(sorted_idx) => {
-                let idx = self.values.len();
+                let idx = self.values.len() as u16;
                 self.values.push(value);
 
                 self.sorted.insert(sorted_idx, idx);
@@ -602,7 +602,7 @@ impl<'input> Namespaces<'input> {
     fn exists(&self, start: usize, prefix: Option<&str>) -> bool {
         self.tree[start..]
             .iter()
-            .any(|idx| self.values[*idx].name == prefix)
+            .any(|idx| self.values[*idx as usize].name == prefix)
     }
 
     fn shrink_to_fit(&mut self) {
@@ -615,7 +615,7 @@ impl<'input> Namespaces<'input> {
 #[derive(Clone, Copy, Debug)]
 struct ExpandedNameIndexed<'input> {
     /// Indexes into `Namspaces::values`
-    namespace_idx: Option<u32>,
+    namespace_idx: Option<u16>,
     local_name: &'input str,
 }
 
@@ -1033,7 +1033,9 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
 
         let doc = self.doc;
 
-        indices.iter().map(move |idx| &doc.namespaces.values[*idx])
+        indices
+            .iter()
+            .map(move |idx| &doc.namespaces.values[*idx as usize])
     }
 
     /// Returns node's text.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1169,11 +1169,10 @@ fn get_ns_idx_by_prefix<'input>(
 
     let idx = doc.namespaces.tree[range.to_urange()]
         .iter()
-        .map(|idx| &doc.namespaces.values[*idx])
-        .position(|ns| ns.name == prefix_opt);
+        .find(|idx| doc.namespaces.values[**idx].name == prefix_opt);
 
     match idx {
-        Some(idx) => Ok(Some(range.start + idx as u32)),
+        Some(idx) => Ok(Some(*idx as u32)),
         None => {
             if !prefix.is_empty() {
                 // If an URI was not found and prefix IS NOT empty than

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -809,7 +809,7 @@ fn resolve_namespaces(start_idx: usize, parent_id: NodeId, doc: &mut Document) -
         for i in parent_ns.to_urange() {
             if !doc.namespaces.exists(
                 start_idx,
-                doc.namespaces.values[doc.namespaces.tree[i]].name,
+                doc.namespaces.values[doc.namespaces.tree[i] as usize].name,
             ) {
                 doc.namespaces.push_ref(i);
             }
@@ -1156,7 +1156,7 @@ fn get_ns_idx_by_prefix<'input>(
     doc: &Document<'input>,
     range: ShortRange,
     prefix: StrSpan,
-) -> Result<Option<u32>, Error> {
+) -> Result<Option<u16>, Error> {
     // Prefix CAN be empty when the default namespace was defined.
     //
     // Example:
@@ -1169,10 +1169,10 @@ fn get_ns_idx_by_prefix<'input>(
 
     let idx = doc.namespaces.tree[range.to_urange()]
         .iter()
-        .find(|idx| doc.namespaces.values[**idx].name == prefix_opt);
+        .find(|idx| doc.namespaces.values[**idx as usize].name == prefix_opt);
 
     match idx {
-        Some(idx) => Ok(Some(*idx as u32)),
+        Some(idx) => Ok(Some(*idx)),
         None => {
             if !prefix.is_empty() {
                 // If an URI was not found and prefix IS NOT empty than

--- a/tests/ast.rs
+++ b/tests/ast.rs
@@ -137,9 +137,10 @@ fn _to_yaml(doc: &Document, s: &mut String) -> Result<(), fmt::Error> {
                         }
                     }
 
-                    if !child.namespaces().is_empty() {
+                    let namespaces = child.namespaces();
+                    if namespaces.len() != 0 {
                         let mut ns_list = Vec::new();
-                        for ns in child.namespaces() {
+                        for ns in namespaces {
                             let name = ns.name().unwrap_or("None");
                             let uri = if ns.uri().is_empty() {
                                 "\"\""


### PR DESCRIPTION
While we do not expand namespaces into attributes any more, we still store redundantly expanded namespaces as we traverse the document tree during parsing. Now that we have the interface that puts namespaces behind an indirection, we fully deduplicate them using a sorted list of indexes.

This does not improve memory consumption on `greater_london.osm` as that document does not use any namespaces, but a for a [CSW response](https://en.wikipedia.org/wiki/Catalogue_Service_for_the_Web) of 25 MB I had lying around, this does decrease memory consumption from 120 MB to 108 MB, i.e. by almost 10%.

The benchmarks are actually a mixed bag instead of regressions throughout, most likely due to the improved locality of a smaller working set:

```
 name                                    master ns/iter  dedup-namespaces ns/iter  diff ns/iter   diff %  speedup 
 large_roxmltree                         4,020,847       3,431,061                     -589,786  -14.67%   x 1.17 
 medium_roxmltree                        804,519         810,177                          5,658    0.70%   x 0.99 
 roxmltree_iter_children                 3,586           3,574                              -12   -0.33%   x 1.00 
 roxmltree_iter_descendants_expensive    128,694         128,552                           -142   -0.11%   x 1.00 
 roxmltree_iter_descendants_inexpensive  44,570          44,731                             161    0.36%   x 1.00 
 tiny_roxmltree                          4,860           4,918                               58    1.19%   x 0.99 
```