### PR TITLE
RFC: Deduplicate tag and attribute names

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -875,16 +875,16 @@ fn resolve_attributes<'input>(
         };
 
         // Check for duplicated attributes.
-        if doc.attrs[start_idx..]
-            .iter()
-            .any(|attr| attr.name.as_expanded_name(doc) == attr_name.as_expanded_name(doc))
-        {
+        if doc.attrs[start_idx..].iter().any(|attr| {
+            doc.expanded_names.values[attr.name_idx as usize].as_expanded_name(doc)
+                == attr_name.as_expanded_name(doc)
+        }) {
             let pos = err_pos_from_qname(doc.text, attr.prefix, attr.local);
             return Err(Error::DuplicatedAttribute(attr.local.to_string(), pos));
         }
 
         doc.attrs.push(AttributeData {
-            name: attr_name,
+            name_idx: doc.expanded_names.resolve(attr_name),
             value: attr.value,
             #[cfg(feature = "positions")]
             pos: attr.pos,


### PR DESCRIPTION
This is a follow-up to #80 which reboots deduplication of tag and attribute names using the same technique with a separate sorted list of indexes as employed there.

Since `ExpandedNameIndexed` does contain any allocations itself, the deduplicate has also become easier as we can produce such a value for comparison with a most likely unnecessary allocation. Furthermore, since `ExpandedNameIndexed` would refer to deduplicated namespaces since #80, we still have a high chance of actually deduplicating names across the document.

For `greater_london.osm`, this reduces memory consumption from 6.7 GB to 5.5 GB, i.e. by over 16%. (`doc.expanded_names.values` has 17 entries in this case.)

For the CSW response mentioned in #80, this further reduces memory consumption 108 MB to 100 MB, i.e. by almost 8%.

Benchmarks are still a mixed when compared to `master`, i.e.

```
 name                                    master ns/iter  dedup-tag-attribute-names ns/iter  diff ns/iter   diff %  speedup 
 large_roxmltree                         4,020,847       3,856,116                              -164,731   -4.10%   x 1.04 
 medium_roxmltree                        804,519         1,039,112                               234,593   29.16%   x 0.77 
 roxmltree_iter_children                 3,586           3,027                                      -559  -15.59%   x 1.18 
 roxmltree_iter_descendants_expensive    128,694         128,533                                    -161   -0.13%   x 1.00 
 roxmltree_iter_descendants_inexpensive  44,570          43,330                                   -1,240   -2.78%   x 1.03 
 tiny_roxmltree                          4,860           5,819                                       959   19.73%   x 0.84 
```

while parsing has regressed as expected while iteration has improved when comparing this directly with #80, i.e.

```
 name                                    dedup-namespaces ns/iter  dedup-tag-attribute-names ns/iter  diff ns/iter   diff %  speedup 
 large_roxmltree                         3,431,061                 3,856,116                               425,055   12.39%   x 0.89 
 medium_roxmltree                        810,177                   1,039,112                               228,935   28.26%   x 0.78 
 roxmltree_iter_children                 3,574                     3,027                                      -547  -15.30%   x 1.18 
 roxmltree_iter_descendants_expensive    128,552                   128,533                                     -19   -0.01%   x 1.00 
 roxmltree_iter_descendants_inexpensive  44,731                    43,330                                   -1,401   -3.13%   x 1.03 
 tiny_roxmltree                          4,918                     5,819                                       901   18.32%   x 0.85
```

So in summary, this yields much larger memory savings that apply to more documents compared to #80, but it is also the stronger trade-off against parsing speed.

Considering that even 'greater_londom.osm` uses only 17 unique names, we might actually be able to optimize this by adaptive using a linear search instead of the binary search which should be friendlier towards branch predictors and SIMD optimizations. 