### PR TITLE
Replace &'a str by &'a Cow<'input, str> where this is the backing data type.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,7 @@ impl<'a, 'input> Attribute<'a, 'input> {
     /// assert_eq!(doc.root_element().attributes().nth(1).unwrap().name(), "a");
     /// ```
     #[inline]
-    pub fn name(&self) -> &'a str {
+    pub fn name(&self) -> &'input str {
         self.data.name.local_name
     }
 
@@ -537,7 +537,7 @@ impl<'input> Namespace<'input> {
     /// assert_eq!(doc.root_element().namespaces().nth(0).unwrap().name(), None);
     /// ```
     #[inline]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'input str> {
         self.name
     }
 
@@ -913,7 +913,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     ///
     /// assert_eq!(doc.root_element().lookup_prefix(""), Some("n"));
     /// ```
-    pub fn lookup_prefix(&self, uri: &str) -> Option<&'a str> {
+    pub fn lookup_prefix(&self, uri: &str) -> Option<&'input str> {
         if uri == NS_XML_URI {
             return Some(NS_XML_PREFIX);
         }
@@ -939,7 +939,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     ///
     /// assert_eq!(doc.root_element().lookup_namespace_uri(None), Some("http://www.w3.org"));
     /// ```
-    pub fn lookup_namespace_uri(&self, prefix: Option<&'a str>) -> Option<&'a str> {
+    pub fn lookup_namespace_uri(&self, prefix: Option<&str>) -> Option<&'a str> {
         self.namespaces()
             .find(|ns| ns.name == prefix)
             .map(|v| v.uri.as_ref())

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -570,7 +570,7 @@ fn process_tokens<'input>(
             xmlparser::Token::Comment { text, span } => {
                 doc.append(
                     parent_id,
-                    NodeKind::Comment(text.as_str()),
+                    NodeKind::Comment(Cow::Borrowed(text.as_str())),
                     span.start(),
                     pd.opt.nodes_limit,
                     &mut pd.awaiting_subtree,

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -31,13 +31,16 @@ fn get_text_01() {
     let doc = Document::parse(data).unwrap();
     let root = doc.root_element();
 
-    assert_eq!(root.text(), Some("\n    Text1\n    "));
+    assert_eq!(root.text().map(AsRef::as_ref), Some("\n    Text1\n    "));
     assert_eq!(root.tail(), None);
 
     let item = root.children().nth(1).unwrap();
 
-    assert_eq!(item.text(), Some("\n        Text2\n    "));
-    assert_eq!(item.tail(), Some("\n    Text3\n"));
+    assert_eq!(
+        item.text().map(AsRef::as_ref),
+        Some("\n        Text2\n    ")
+    );
+    assert_eq!(item.tail().map(AsRef::as_ref), Some("\n    Text3\n"));
 }
 
 #[test]
@@ -47,7 +50,7 @@ fn get_text_02() {
     let doc = Document::parse(data).unwrap();
     let root = doc.root_element();
 
-    assert_eq!(root.text(), Some("'"));
+    assert_eq!(root.text().map(AsRef::as_ref), Some("'"));
 }
 
 #[test]
@@ -60,10 +63,14 @@ fn api_01() {
     let doc = Document::parse(data).unwrap();
     let p = doc.root_element();
 
-    assert_eq!(p.attribute("attr"), Some("no_ns"));
+    assert_eq!(p.attribute("attr").map(AsRef::as_ref), Some("no_ns"));
     assert_eq!(p.has_attribute("attr"), true);
 
-    assert_eq!(p.attribute(("http://www.w3.org", "attr")), Some("a_ns"));
+    assert_eq!(
+        p.attribute(("http://www.w3.org", "attr"))
+            .map(AsRef::as_ref),
+        Some("a_ns")
+    );
     assert_eq!(p.has_attribute(("http://www.w3.org", "attr")), true);
 
     assert_eq!(p.attribute("attr2"), None);
@@ -123,10 +130,13 @@ fn lookup_namespace_uri() {
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
     assert_eq!(
-        node.lookup_namespace_uri(Some("n1")),
+        node.lookup_namespace_uri(Some("n1")).map(AsRef::as_ref),
         Some("http://www.w3.org")
     );
-    assert_eq!(node.lookup_namespace_uri(None), Some("http://www.w4.org"));
+    assert_eq!(
+        node.lookup_namespace_uri(None).map(AsRef::as_ref),
+        Some("http://www.w4.org")
+    );
     assert_eq!(node.lookup_namespace_uri(Some("n2")), None);
 }
 

--- a/tests/dom-api.rs
+++ b/tests/dom-api.rs
@@ -154,7 +154,7 @@ fn get_element_by_id() {
     let doc = Document::parse(data).unwrap();
     let elem = doc
         .descendants()
-        .find(|n| n.attribute("id") == Some("rect1"))
+        .find(|n| n.attribute("id").map(AsRef::as_ref) == Some("rect1"))
         .unwrap();
     assert!(elem.has_tag_name("rect"));
 }


### PR DESCRIPTION
I started converting return types from `&'a str` to `&'a Cow<'input, str>` and there is indeed some loss ergonomics as calling code must call `.map(AsRef::as_ref)` to e.g. compare against `Option<&str>`.

We could work around this by providing `*_cow` methods returning `Option<&'a Cow<'input, str>>` and implement the existing methods as `.map(AsRef::as_ref)` on top of those so that no implementations need to be duplicated. But that would imply a significant increase in API surface for purely technical reasons.

Another issue that should however be solvable by adding another internal type is that `ExpandedName` does double duty a) holding references to expanded names from within the document to returned from `Node::tag_name` which would need to store `&'a Cow<'input, str>` and b) holding values passed into the API for matching purposes like `Node::has_tag_name` which need to store `&'c str` with an unrelated lifetime `'c`.

Closes #88