### PR TITLE
Avoid redundant tuple layer for ExpandedName::from_static

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,12 +755,12 @@ impl ExpandedName<'static, 'static> {
     /// ```rust
     /// use roxmltree::ExpandedName;
     /// const DAV_HREF: ExpandedName =
-    ///     ExpandedName::from_static(("urn:ietf:params:xml:ns:caldav:", "calendar-data"));
+    ///     ExpandedName::from_static("urn:ietf:params:xml:ns:caldav:", "calendar-data");
     /// ```
-    pub const fn from_static(v: (&'static str, &'static str)) -> Self {
-        ExpandedName {
-            uri: Some(v.0),
-            name: v.1,
+    pub const fn from_static(uri: &'static str, name: &'static str) -> Self {
+        Self {
+            uri: Some(uri),
+            name,
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -503,7 +503,7 @@ fn parse(text: &str, opt: ParsingOptions) -> Result<Document, Error> {
         last_child: None,
         kind: NodeKind::Root,
         #[cfg(feature = "positions")]
-        range: (0..text.len()).into(),
+        range: 0..text.len(),
     });
 
     doc.namespaces

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -143,7 +143,10 @@ fn text_pos_01() {
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
 
-    assert_eq!(doc.text_pos_at(doc.root().range().start), TextPos::new(1, 1));
+    assert_eq!(
+        doc.text_pos_at(doc.root().range().start),
+        TextPos::new(1, 1)
+    );
     assert_eq!(doc.text_pos_at(doc.root().range().end), TextPos::new(5, 1));
 
     assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));


### PR DESCRIPTION
Since the method has to be called explicitly, the tuple layer serves no functional purposes.

This split in API conventions has precedence in the standard library, e.g. `HashMap::retain` accepting a two-argument closure versus `impl FromIterator for HashMap` expecting key-value pairs.

cc @WhyNotHugo 