### PR TITLE
Fix xmlparser features for no_std build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ members = ["benches"]
 exclude = ["test-apps", "testing-tools"]
 
 [dependencies]
-xmlparser = "0.13.5"
+xmlparser = { version = "0.13.5", default-features = false }
 
 [features]
 default = ["std", "positions"]
-std = []
+std = ["xmlparser/std"]
 # Enables Nodes and Attributes position in the original document preserving.
 # Increases memory usage by `usize` for each Node and Attribute.
 positions = []


### PR DESCRIPTION
_xmlparser_ relies on `std` by default, unless the `xmlparser/std` feature is disabled. Conditionally enable this feature depending on `roxmltree/std`.

Fixes #38.