### PR TITLE
RFC: Add note on availability of serde-roxmltree as an additional API layer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ This library uses Rust's idiomatic API based on iterators.
 In case you are more familiar with browser/JS DOM APIs - you can check out
 [tests/dom-api.rs](tests/dom-api.rs) to see how it can be mapped onto the Rust one.
 
+Built on top of this API, a mapping to the [Serde data model](https://serde.rs/data-model.html)
+is available via the [`serde-roxmltree` crate](https://crates.io/crates/serde-roxmltree).
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
We have been happily using `serde-roxmltree` in addition to the native API for our XML parsing needs for quite some time now and I have recently added opt-in support for namespaces, so by now I feel like `serde-roxmltree` can be a useful way to reduce the boiler plate of the iterator-based API when deserializing simple documents.

Hence I think it would be helpful to make potential users of this crate aware of the "add-on" crate. Of course, I understand if you want to avoid playing favourites or being associated with a crate which you do not control, hence the RFC moniker.