### PR TITLE
Drop sorted_order after parsing as it is not used anymore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,7 +756,8 @@ impl<'input> Namespaces<'input> {
     fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
         self.tree_order.shrink_to_fit();
-        self.sorted_order.shrink_to_fit();
+        // Only needed to deduplicate namespaces during parsing.
+        self.sorted_order = Vec::new();
     }
 
     #[inline]


### PR DESCRIPTION
After parsing, nothing in the public API actually accesses `sorted_order` which is only used to deduplicate namespaces encountered during the parsing process. Hence, we can free the memory immediately after parsing.