### PR TITLE
Avoid panic if entity resolution yields unbalanced tags.

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -40,7 +40,6 @@ pub enum Error {
     /// Incorrect tree structure.
     ///
     /// expected, actual, position
-    #[allow(missing_docs)]
     UnexpectedCloseTag(String, String, TextPos),
 
     /// Entity value starts with a close tag.
@@ -818,7 +817,13 @@ fn process_element<'input>(
                 ctx.parent_prefixes.pop();
                 debug_assert!(!ctx.parent_prefixes.is_empty());
             } else {
-                unreachable!("should be already checked by the tokenizer");
+                // May occur in XML like this:
+                // <!DOCTYPE test [ <!ENTITY p '<p></p></p>'> ]>
+                // <p>&p;&p;
+
+                return Err(Error::UnexpectedEntityCloseTag(
+                    ctx.err_pos_at(token_range.start),
+                ));
             }
         }
         tokenizer::ElementEnd::Open => {

--- a/tests/ast.rs
+++ b/tests/ast.rs
@@ -242,6 +242,7 @@ test!(entity_err_006);
 test!(entity_err_007);
 test!(entity_err_008);
 test!(entity_err_009);
+test!(entity_err_010);
 test!(ns_001);
 test!(ns_002);
 test!(ns_003);

--- a/tests/files/entity_err_010.xml
+++ b/tests/files/entity_err_010.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE test [
+    <!ENTITY p '<p></p></p>'>
+]>
+<p>&p;&p;

--- a/tests/files/entity_err_010.yaml
+++ b/tests/files/entity_err_010.yaml
@@ -1,0 +1,1 @@
+error: "unexpected close tag at 2:24"


### PR DESCRIPTION
It would be preferable if the entity chunk itself were rejected as unbalanced as lxml does, but I think this would require tracking additional state for the current entity chunk and therefore I decided to handle only the fallout.

(Without a DTD involved, this would trigger an unknown token error from `tokenizer::parse` as the parser just sees trailing data after the last valid close tag, but with the DTD involved `tokenizer::parse_content` lacks the context that all elements have been closed.)

Closes #124