### PR TITLE
Devirtualize XmlEvents dispatch to give the optimizer full visibility

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -608,6 +608,7 @@ fn parse(text: &str, opt: ParsingOptions) -> Result<Document> {
 }
 
 impl<'input> tokenizer::XmlEvents<'input> for Context<'input> {
+    #[inline(always)]
     fn token(&mut self, token: tokenizer::Token<'input>) -> Result<()> {
         match token {
             tokenizer::Token::ProcessingInstruction(target, value, range) => {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -192,7 +192,7 @@ pub trait XmlEvents<'input> {
 pub fn parse<'input>(
     text: &'input str,
     allow_dtd: bool,
-    events: &mut dyn XmlEvents<'input>,
+    events: &mut impl XmlEvents<'input>,
 ) -> Result<()> {
     let s = &mut Stream::new(text);
 
@@ -232,7 +232,7 @@ pub fn parse<'input>(
 }
 
 // Misc ::= Comment | PI | S
-fn parse_misc<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_misc<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     while !s.at_end() {
         s.skip_spaces();
         if s.starts_with(b"<!--") {
@@ -292,7 +292,7 @@ fn parse_declaration(s: &mut Stream) -> Result<()> {
 }
 
 // '<!--' ((Char - '-') | ('-' (Char - '-')))* '-->'
-fn parse_comment<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_comment<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     let start = s.pos();
     s.advance(4);
     let text = s.consume_chars(|s, c| !(c == '-' && s.starts_with(b"-->")))?;
@@ -314,7 +314,7 @@ fn parse_comment<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'inp
 
 // PI       ::= '<?' PITarget (S (Char* - (Char* '?>' Char*)))? '?>'
 // PITarget ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
-fn parse_pi<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_pi<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     if s.starts_with(b"<?xml ") {
         return Err(Error::UnexpectedDeclaration(s.gen_text_pos()));
     }
@@ -337,7 +337,7 @@ fn parse_pi<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) 
     Ok(())
 }
 
-fn parse_doctype<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_doctype<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     let start = s.pos();
     parse_doctype_start(s)?;
     s.skip_spaces();
@@ -441,7 +441,7 @@ fn parse_external_id(s: &mut Stream) -> Result<bool> {
 // PEDecl      ::= '<!ENTITY' S '%' S Name S PEDef S? '>'
 fn parse_entity_decl<'input>(
     s: &mut Stream<'input>,
-    events: &mut dyn XmlEvents<'input>,
+    events: &mut impl XmlEvents<'input>,
 ) -> Result<()> {
     s.advance(8);
     s.consume_spaces()?;
@@ -516,7 +516,7 @@ fn consume_decl(s: &mut Stream) -> Result<()> {
 
 // element ::= EmptyElemTag | STag content ETag
 // '<' Name (S Attribute)* S? '>'
-fn parse_element<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_element<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     let start = s.pos();
     s.advance(1); // <
     let (prefix, local) = s.consume_qname()?;
@@ -596,7 +596,7 @@ fn parse_attribute<'input>(
 // content ::= CharData? ((element | Reference | CDSect | PI | Comment) CharData?)*
 pub fn parse_content<'input>(
     s: &mut Stream<'input>,
-    events: &mut dyn XmlEvents<'input>,
+    events: &mut impl XmlEvents<'input>,
 ) -> Result<()> {
     while !s.at_end() {
         match s.curr_byte() {
@@ -630,7 +630,7 @@ pub fn parse_content<'input>(
 // CDStart ::= '<![CDATA['
 // CData   ::= (Char* - (Char* ']]>' Char*))
 // CDEnd   ::= ']]>'
-fn parse_cdata<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_cdata<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     let start = s.pos();
     s.advance(9); // <![CDATA[
     let text = s.consume_chars(|s, c| !(c == ']' && s.starts_with(b"]]>")))?;
@@ -643,7 +643,7 @@ fn parse_cdata<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input
 // '</' Name S? '>'
 fn parse_close_element<'input>(
     s: &mut Stream<'input>,
-    events: &mut dyn XmlEvents<'input>,
+    events: &mut impl XmlEvents<'input>,
 ) -> Result<()> {
     let start = s.pos();
     s.advance(2); // </
@@ -660,7 +660,7 @@ fn parse_close_element<'input>(
     Ok(())
 }
 
-fn parse_text<'input>(s: &mut Stream<'input>, events: &mut dyn XmlEvents<'input>) -> Result<()> {
+fn parse_text<'input>(s: &mut Stream<'input>, events: &mut impl XmlEvents<'input>) -> Result<()> {
     let start = s.pos();
     let text = s.consume_chars(|_, c| c != '<')?;
 


### PR DESCRIPTION
As `XmlEvents` is not public API any more, there should be no possibility of code bloat due to multiple instantiations and we can safely monomorphise dispatch from the tokenizer into the parser.

This yields small but measurable improvements in the benchmarks, but only after marking the single implementation of `XmlEvents::token` as `#[inline(always)]`, so possibly by avoiding one level of dispatching on the token type, c.f. before

```
test huge_roxmltree                         ... bench:   5,394,963 ns/iter (+/- 143,581)
test large_roxmltree                        ... bench:   2,646,532 ns/iter (+/- 19,663)
test medium_roxmltree                       ... bench:     698,086 ns/iter (+/- 70,686)
test tiny_roxmltree                         ... bench:       4,236 ns/iter (+/- 99)
```

and after

```
test huge_roxmltree                         ... bench:   5,167,046 ns/iter (+/- 227,797)
test large_roxmltree                        ... bench:   2,422,624 ns/iter (+/- 47,267)
test medium_roxmltree                       ... bench:     685,669 ns/iter (+/- 23,478)
test tiny_roxmltree                         ... bench:       3,936 ns/iter (+/- 56)
```  