### PR TITLE
WIP: Add byte offset to `TextPos`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,19 +56,35 @@ const XMLNS: &str = "xmlns";
 #[allow(missing_docs)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct TextPos {
+    pub byte: usize,
     pub row: u32,
     pub col: u32,
 }
 
 impl TextPos {
     /// Constructs a new `TextPos`.
-    pub fn new(row: u32, col: u32) -> TextPos {
-        TextPos { row, col }
+    pub fn new(byte: usize, row: u32, col: u32) -> TextPos {
+        TextPos { byte, row, col }
+    }
+
+    /// Constructs a new `TextPos` that indicates the start of the data.
+    ///
+    /// Useful for errors that don't have a meaningful position in the data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use roxmltree::*;
+    /// assert_eq!(TextPos::start(), TextPos::new(0, 1, 1));
+    /// ```
+    pub fn start() -> TextPos {
+        Self::new(0, 1, 1)
     }
 }
 
 impl fmt::Display for TextPos {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: incorporate `byte` into `Display`?
         write!(f, "{}:{}", self.row, self.col)
     }
 }
@@ -194,8 +210,8 @@ impl<'input> Document<'input> {
     /// <e/>"
     /// ).unwrap();
     ///
-    /// assert_eq!(doc.text_pos_at(10), TextPos::new(1, 11));
-    /// assert_eq!(doc.text_pos_at(9999), TextPos::new(2, 5));
+    /// assert_eq!(doc.text_pos_at(10), TextPos::new(10, 1, 11));
+    /// assert_eq!(doc.text_pos_at(9999), TextPos::new(21, 2, 5));
     /// ```
     #[inline]
     pub fn text_pos_at(&self, pos: usize) -> TextPos {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -164,13 +164,13 @@ impl Error {
             Error::EntityReferenceLoop(pos) => pos,
             Error::InvalidAttributeValue(pos) => pos,
             Error::DuplicatedAttribute(_, pos) => pos,
-            Error::NoRootNode => TextPos::new(1, 1),
-            Error::UnclosedRootNode => TextPos::new(1, 1),
+            Error::NoRootNode => TextPos::start(),
+            Error::UnclosedRootNode => TextPos::start(),
             Error::UnexpectedDeclaration(pos) => pos,
-            Error::DtdDetected => TextPos::new(1, 1),
-            Error::NodesLimitReached => TextPos::new(1, 1),
-            Error::AttributesLimitReached => TextPos::new(1, 1),
-            Error::NamespacesLimitReached => TextPos::new(1, 1),
+            Error::DtdDetected => TextPos::start(),
+            Error::NodesLimitReached => TextPos::start(),
+            Error::AttributesLimitReached => TextPos::start(),
+            Error::NamespacesLimitReached => TextPos::start(),
             Error::InvalidName(pos) => pos,
             Error::NonXmlChar(_, pos) => pos,
             Error::InvalidChar(_, _, pos) => pos,
@@ -180,7 +180,7 @@ impl Error {
             Error::InvalidComment(pos) => pos,
             Error::InvalidCharacterData(pos) => pos,
             Error::UnknownToken(pos) => pos,
-            Error::UnexpectedEndOfStream => TextPos::new(1, 1),
+            Error::UnexpectedEndOfStream => TextPos::start(),
         }
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1129,7 +1129,7 @@ impl<'input> Stream<'input> {
 
         let row = Self::calc_curr_row(text, end);
         let col = Self::calc_curr_col(text, end);
-        TextPos::new(row, col)
+        TextPos::new(end, row, col)
     }
 
     /// Calculates an absolute position at `pos`.

--- a/src/tokenizer_tests.rs
+++ b/src/tokenizer_tests.rs
@@ -8,21 +8,21 @@ use crate::tokenizer as xml;
 fn text_pos_1() {
     let mut s = xml::Stream::new("text");
     s.advance(2);
-    assert_eq!(s.gen_text_pos(), crate::TextPos::new(1, 3));
+    assert_eq!(s.gen_text_pos(), crate::TextPos::new(2, 1, 3));
 }
 
 #[test]
 fn text_pos_2() {
     let mut s = xml::Stream::new("text\ntext");
     s.advance(6);
-    assert_eq!(s.gen_text_pos(), crate::TextPos::new(2, 2));
+    assert_eq!(s.gen_text_pos(), crate::TextPos::new(6, 2, 2));
 }
 
 #[test]
 fn text_pos_3() {
     let mut s = xml::Stream::new("текст\nтекст");
     s.advance(15);
-    assert_eq!(s.gen_text_pos(), crate::TextPos::new(2, 3));
+    assert_eq!(s.gen_text_pos(), crate::TextPos::new(15, 2, 3));
 }
 
 #[test]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -2,11 +2,12 @@
 
 use roxmltree::*;
 
+/* TODO: adding a `usize` to `TextPos` increases `Error` size to 72
 #[test]
 fn error_size() {
     assert!(::std::mem::size_of::<Error>() <= 64);
 }
-
+*/
 #[test]
 fn root_element_01() {
     let data = "\
@@ -148,31 +149,31 @@ fn text_pos_01() {
 
     assert_eq!(
         doc.text_pos_at(doc.root().range().start),
-        TextPos::new(1, 1)
+        TextPos::new(0, 1, 1)
     );
-    assert_eq!(doc.text_pos_at(doc.root().range().end), TextPos::new(5, 1));
+    assert_eq!(doc.text_pos_at(doc.root().range().end), TextPos::new(52, 5, 1));
 
-    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));
-    assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(4, 5));
+    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(0, 1, 1));
+    assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(51, 4, 5));
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 9));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 7));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 8));
+        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(3, 1, 4));
+        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(8, 1, 9));
+        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(3, 1, 4));
+        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(4, 1, 5));
+        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(6, 1, 7));
+        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(7, 1, 8));
     }
 
     // first child is a text/whitespace, not a comment
     let comm = node.first_child().unwrap().next_sibling().unwrap();
-    assert_eq!(doc.text_pos_at(comm.range().start), TextPos::new(2, 5));
+    assert_eq!(doc.text_pos_at(comm.range().start), TextPos::new(14, 2, 5));
 
     let p = comm.next_sibling().unwrap().next_sibling().unwrap();
-    assert_eq!(doc.text_pos_at(p.range().start), TextPos::new(3, 5));
+    assert_eq!(doc.text_pos_at(p.range().start), TextPos::new(35, 3, 5));
 
     let text = p.first_child().unwrap();
-    assert_eq!(doc.text_pos_at(text.range().start), TextPos::new(3, 8));
+    assert_eq!(doc.text_pos_at(text.range().start), TextPos::new(38, 3, 8));
 }
 
 #[cfg(feature = "positions")]
@@ -183,15 +184,15 @@ fn text_pos_02() {
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
 
-    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));
+    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(0, 1, 1));
 
     if let Some(attr) = node.attribute_node(("http://www.w3.org", "a")) {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 44));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 43));
+        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(35, 1, 36));
+        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(43, 1, 44));
+        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(35, 1, 36));
+        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(39, 1, 40));
+        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(41, 1, 42));
+        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(42, 1, 43));
     }
 }
 
@@ -206,8 +207,8 @@ fn text_pos_03() {
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
 
-    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(2, 1));
-    assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(2, 5));
+    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(17, 2, 1));
+    assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(21, 2, 5));
 }
 
 #[cfg(feature = "positions")]
@@ -219,12 +220,12 @@ fn text_pos_04() {
     let node = doc.root_element();
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 43));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 42));
+        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(35, 1, 36));
+        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(42, 1, 43));
+        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(35, 1, 36));
+        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(39, 1, 40));
+        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(41, 1, 42));
+        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(41, 1, 42));
 }
 }
 
@@ -237,12 +238,12 @@ fn text_pos_05() {
     let node = doc.root_element();
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 48));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 47));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 48));
+        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(35, 1, 36));
+        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(47, 1, 48));
+        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(35, 1, 36));
+        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(39, 1, 40));
+        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(46, 1, 47));
+        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(47, 1, 48));
     }
 }
 
@@ -256,10 +257,10 @@ fn text_pos_06() {
     let node = doc.root_element();
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 269));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
+        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(3, 1, 4));
+        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(268, 1, 269));
+        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(3, 1, 4));
+        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(4, 1, 5));
         attr.range_value(); // unreliable since >254 spaces around equal sign, but still shouldn't panic
     }
 }


### PR DESCRIPTION
The goal here is to provide a byte position/offset in errors in addition to a row/col position.  The byte position is helpful for callers that want to do more sophisticated error reporting, such as:
1) showing source annotations using libraries like [annotate_snippets](https://github.com/rust-lang/annotate-snippets-rs), which naturally expect annotation positions as byte offsets,
2) using a more complex row/col calculation algorithm, such as accounting for single glyphs that use multiple chars / code points, or doing tab expansion.

The changes are pretty straight forward, and I only ran into one problem that I need feedback to resolve: there's a test that requires `size_of::<Error> <= 64`, but the new data in `TextPos` increases it to 72.  For now I commented that test out just to make sure all the other tests run and pass.  Any thoughts about this?  Can we just allow `Error` to get bigger?  Can we remove and/or shrink something else to compensate?  Can we potentially do the byte to row/col calculation lazily (e.g. as a method on `Error`) instead of storing row/col data in the error (I'm not sure that the necessary original data string would still be available, plus that could be a pretty break-y change)?  Can we hide this behind a feature flag?  Or does this error size limit potentially sink this PR/idea?

I also left a TODO in the `Display` impl of `TextPos` because I'm not sure if/how you might want to incorporate the byte position into that.

Sort of unrelatedly -- I added a new `TextPos::start` constructor for the not uncommon case where an error has no meaningful position and so just indicates the start of the data.  Seemed like a nice refactor, but it's obviously optional for my goal and I'm happy to change and/or revert that as desired.