### PR TITLE
WIP: BREAKING CHANGE: Store byte offset in `Error` instead of `TextPos`.

### DIFF
--- a/examples/print_pos.rs
+++ b/examples/print_pos.rs
@@ -26,7 +26,7 @@ fn main() {
             println!(
                 "{:?} at {}",
                 node.tag_name(),
-                doc.text_pos_at(node.range().start)
+                roxmltree::text_pos(&text, node.range().start)
             );
         }
     }

--- a/src/tokenizer_tests.rs
+++ b/src/tokenizer_tests.rs
@@ -5,27 +5,6 @@ use std::vec::Vec;
 use crate::tokenizer as xml;
 
 #[test]
-fn text_pos_1() {
-    let mut s = xml::Stream::new("text");
-    s.advance(2);
-    assert_eq!(s.gen_text_pos(), crate::TextPos::new(1, 3));
-}
-
-#[test]
-fn text_pos_2() {
-    let mut s = xml::Stream::new("text\ntext");
-    s.advance(6);
-    assert_eq!(s.gen_text_pos(), crate::TextPos::new(2, 2));
-}
-
-#[test]
-fn text_pos_3() {
-    let mut s = xml::Stream::new("текст\nтекст");
-    s.advance(15);
-    assert_eq!(s.gen_text_pos(), crate::TextPos::new(2, 3));
-}
-
-#[test]
 fn token_size() {
     assert!(::std::mem::size_of::<Token>() <= 196);
 }
@@ -47,7 +26,7 @@ pub enum Token<'a> {
     ElementEnd(ElementEnd<'a>, Range),
     Text(&'a str, Range),
     Cdata(&'a str, Range),
-    Error(String),
+    Error(usize, String),
 }
 
 #[derive(PartialEq, Debug)]
@@ -113,7 +92,7 @@ impl<'a> xml::XmlEvents<'a> for EventsCollector<'a> {
 pub fn collect_tokens(text: &str) -> Vec<Token> {
     let mut collector = EventsCollector { tokens: Vec::new() };
     if let Err(e) = xml::parse(text, true, &mut collector) {
-        collector.tokens.push(Token::Error(e.to_string()));
+        collector.tokens.push(Token::Error(e.pos(), e.to_string()));
     }
     collector.tokens
 }
@@ -209,7 +188,7 @@ test!(
     "<p><![CDATA[\u{1}]]></p>",
     Token::ElementStart("", "p", 0),
     Token::ElementEnd(ElementEnd::Open, 2..3),
-    Token::Error("a non-XML character '\\u{1}' found at 1:13".to_string())
+    Token::Error(12, "a non-XML character '\\u{1}' found".to_string())
 );
 
 // Comments
@@ -388,31 +367,31 @@ fn dtd_entity_07() {
 test!(
     dtd_err_01,
     "<!DOCTYPEEG[<!ENTITY%ETT\u{000a}SSSSSSSS<D_IDYT;->\u{000a}<",
-    Token::Error("expected a whitespace not 'E' at 1:10".to_string())
+    Token::Error(9, "expected a whitespace not 'E'".to_string())
 );
 
 test!(
     dtd_err_02,
     "<!DOCTYPE s [<!ENTITY % name S YSTEM",
-    Token::Error("invalid ExternalID at 1:30".to_string())
+    Token::Error(29, "invalid ExternalID".to_string())
 );
 
 test!(
     dtd_err_03,
     "<!DOCTYPE s [<!ENTITY % name B",
-    Token::Error("expected a quote, SYSTEM or PUBLIC not 'B' at 1:30".to_string())
+    Token::Error(29, "expected a quote, SYSTEM or PUBLIC not 'B'".to_string())
 );
 
 test!(
     dtd_err_04,
     "<!DOCTYPE s []",
-    Token::Error("unexpected end of stream".to_string())
+    Token::Error(0, "unexpected end of stream".to_string())
 );
 
 test!(
     dtd_err_05,
     "<!DOCTYPE s [] !",
-    Token::Error("expected '>' not '!' at 1:16".to_string())
+    Token::Error(15, "expected '>' not '!'".to_string())
 );
 
 // Document
@@ -461,38 +440,38 @@ test!(
 test!(
     document_err_01,
     "<![CDATA[text]]>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     document_err_02,
     " &www---------Ӥ+----------w-----www_",
-    Token::Error("unknown token at 1:2".to_string())
+    Token::Error(1, "unknown token".to_string())
 );
 
 test!(
     document_err_03,
     "q",
-    Token::Error("unknown token at 1:1".to_string())
+    Token::Error(0, "unknown token".to_string())
 );
 
 test!(
     document_err_04,
     "<!>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 // TODO: better error
 test!(
     document_err_05,
     "<!DOCTYPE greeting1><!DOCTYPE greeting2>",
-    Token::Error("invalid name token at 1:22".to_string())
+    Token::Error(21, "invalid name token".to_string())
 );
 
 test!(
     document_err_06,
     "&#x20;",
-    Token::Error("unknown token at 1:1".to_string())
+    Token::Error(0, "unknown token".to_string())
 );
 
 // Elements
@@ -557,19 +536,19 @@ test!(
 test!(
     element_err_01,
     "<>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_02,
     "</",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_03,
     "</a",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
@@ -577,31 +556,31 @@ test!(
     "<a x='test' /",
     Token::ElementStart("", "a", 0),
     Token::Attribute("", "x", "test"),
-    Token::Error("unexpected end of stream".to_string())
+    Token::Error(0, "unexpected end of stream".to_string())
 );
 
 test!(
     element_err_05,
     "<<",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_06,
     "< a",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_07,
     "< ",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_08,
     "<&#x9;",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
@@ -610,7 +589,7 @@ test!(
     Token::ElementStart("", "a", 0),
     Token::ElementEnd(ElementEnd::Open, 2..3),
     Token::ElementEnd(ElementEnd::Close("", "a"), 3..7),
-    Token::Error("unknown token at 1:8".to_string())
+    Token::Error(7, "unknown token".to_string())
 );
 
 test!(
@@ -618,7 +597,7 @@ test!(
     "<a/><a/>",
     Token::ElementStart("", "a", 0),
     Token::ElementEnd(ElementEnd::Empty, 2..4),
-    Token::Error("unknown token at 1:5".to_string())
+    Token::Error(4, "unknown token".to_string())
 );
 
 test!(
@@ -626,13 +605,13 @@ test!(
     "<a></br/></a>",
     Token::ElementStart("", "a", 0),
     Token::ElementEnd(ElementEnd::Open, 2..3),
-    Token::Error("expected '>' not '/' at 1:8".to_string())
+    Token::Error(7, "expected '>' not '/'".to_string())
 );
 
 test!(
     element_err_12,
     "<svg:/>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
@@ -645,37 +624,37 @@ test!(
     Token::ElementEnd(ElementEnd::Open, 5..6),
     Token::Text("\n", 6..7),
     Token::ElementEnd(ElementEnd::Close("", "root"), 7..14),
-    Token::Error("unknown token at 3:1".to_string())
+    Token::Error(15, "unknown token".to_string())
 );
 
 test!(
     element_err_14,
     "<-svg/>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_15,
     "<svg:-svg/>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_16,
     "<svg::svg/>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_17,
     "<svg:s:vg/>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
     element_err_18,
     "<::svg/>",
-    Token::Error("invalid name token at 1:2".to_string())
+    Token::Error(1, "invalid name token".to_string())
 );
 
 test!(
@@ -683,7 +662,7 @@ test!(
     "<a><",
     Token::ElementStart("", "a", 0),
     Token::ElementEnd(ElementEnd::Open, 2..3),
-    Token::Error("unknown token at 1:4".to_string())
+    Token::Error(3, "unknown token".to_string())
 );
 
 test!(
@@ -749,21 +728,21 @@ test!(
     attribute_err_01,
     "<c az=test>",
     Token::ElementStart("", "c", 0),
-    Token::Error("expected a quote not 't' at 1:7".to_string())
+    Token::Error(6, "expected a quote not 't'".to_string())
 );
 
 test!(
     attribute_err_02,
     "<c a>",
     Token::ElementStart("", "c", 0),
-    Token::Error("expected \'=\' not \'>\' at 1:5".to_string())
+    Token::Error(4, "expected \'=\' not \'>\'".to_string())
 );
 
 test!(
     attribute_err_03,
     "<c a/>",
     Token::ElementStart("", "c", 0),
-    Token::Error("expected '=' not '/' at 1:5".to_string())
+    Token::Error(4, "expected '=' not '/'".to_string())
 );
 
 test!(
@@ -771,21 +750,21 @@ test!(
     "<c a='b' q/>",
     Token::ElementStart("", "c", 0),
     Token::Attribute("", "a", "b"),
-    Token::Error("expected '=' not '/' at 1:11".to_string())
+    Token::Error(10, "expected '=' not '/'".to_string())
 );
 
 test!(
     attribute_err_05,
     "<c a='<'/>",
     Token::ElementStart("", "c", 0),
-    Token::Error("expected ''' not '<' at 1:7".to_string())
+    Token::Error(6, "expected ''' not '<'".to_string())
 );
 
 test!(
     attribute_err_06,
     "<c a='\u{1}'/>",
     Token::ElementStart("", "c", 0),
-    Token::Error("a non-XML character '\\u{1}' found at 1:7".to_string())
+    Token::Error(6, "a non-XML character '\\u{1}' found".to_string())
 );
 
 test!(
@@ -793,7 +772,7 @@ test!(
     "<c a='v'b='v'/>",
     Token::ElementStart("", "c", 0),
     Token::Attribute("", "a", "v"),
-    Token::Error("expected a whitespace not 'b' at 1:9".to_string())
+    Token::Error(8, "expected a whitespace not 'b'".to_string())
 );
 
 // PI
@@ -819,7 +798,7 @@ test!(
 test!(
     pi_err_01,
     "<??xml \t\n m?>",
-    Token::Error("invalid name token at 1:3".to_string())
+    Token::Error(2, "invalid name token".to_string())
 );
 
 test!(declaration_01, "<?xml version=\"1.0\"?>",);
@@ -852,44 +831,44 @@ test!(declaration_10, "<?xml version='1.0' standalone='no' ?>",);
 test!(
     declaration_err_01,
     "<?xml encoding='UTF-8' version='1.0'?>",
-    Token::Error("expected 'version' at 1:7".to_string())
+    Token::Error(6, "expected 'version'".to_string())
 );
 
 test!(
     declaration_err_05,
     "<?xml version='1.0' yes='true'?>",
-    Token::Error("expected '?>' at 1:21".to_string())
+    Token::Error(20, "expected '?>'".to_string())
 );
 
 test!(
     declaration_err_06,
     "<?xml version='1.0' encoding='UTF-8' standalone='yes' yes='true'?>",
-    Token::Error("expected '?>' at 1:55".to_string())
+    Token::Error(54, "expected '?>'".to_string())
 );
 
 test!(
     declaration_err_07,
     "\u{000a}<?xml\u{000a}&jg'];",
-    Token::Error("expected '?>' at 3:7".to_string())
+    Token::Error(13, "expected '?>'".to_string())
 );
 
 test!(
     declaration_err_08,
     "<?xml \t\n ?m?>",
-    Token::Error("expected 'version' at 2:2".to_string())
+    Token::Error(9, "expected 'version'".to_string())
 );
 
 test!(
     declaration_err_09,
     "<?xml \t\n m?>",
-    Token::Error("expected 'version' at 2:2".to_string())
+    Token::Error(9, "expected 'version'".to_string())
 );
 
 // XML declaration allowed only at the start of the document.
 test!(
     declaration_err_10,
     " <?xml version='1.0'?>",
-    Token::Error("unexpected XML declaration at 1:2".to_string())
+    Token::Error(1, "unexpected XML declaration".to_string())
 );
 
 // XML declaration allowed only at the start of the document.
@@ -897,38 +876,38 @@ test!(
     declaration_err_11,
     "<!-- comment --><?xml version='1.0'?>",
     Token::Comment(" comment ", 0..16),
-    Token::Error("unexpected XML declaration at 1:17".to_string())
+    Token::Error(16, "unexpected XML declaration".to_string())
 );
 
 // Duplicate.
 test!(
     declaration_err_12,
     "<?xml version='1.0'?><?xml version='1.0'?>",
-    Token::Error("unexpected XML declaration at 1:22".to_string())
+    Token::Error(21, "unexpected XML declaration".to_string())
 );
 
 test!(
     declaration_err_13,
     "<?target \u{1}content>",
-    Token::Error("a non-XML character '\\u{1}' found at 1:10".to_string())
+    Token::Error(9, "a non-XML character '\\u{1}' found".to_string())
 );
 
 test!(
     declaration_err_14,
     "<?xml version='1.0'encoding='UTF-8'?>",
-    Token::Error("expected a whitespace not 'e' at 1:20".to_string())
+    Token::Error(19, "expected a whitespace not 'e'".to_string())
 );
 
 test!(
     declaration_err_15,
     "<?xml version='1.0' encoding='UTF-8'standalone='yes'?>",
-    Token::Error("expected a whitespace not 's' at 1:37".to_string())
+    Token::Error(36, "expected a whitespace not 's'".to_string())
 );
 
 test!(
     declaration_err_16,
     "<?xml version='1.0'",
-    Token::Error("expected '?>' at 1:20".to_string())
+    Token::Error(19, "expected '?>'".to_string())
 );
 
 // Text
@@ -1002,7 +981,7 @@ test!(
     "<p>]]></p>",
     Token::ElementStart("", "p", 0),
     Token::ElementEnd(ElementEnd::Open, 2..3),
-    Token::Error("']]>' at 1:7 is not allowed inside a character data".to_string())
+    Token::Error(6, "']]>' is not allowed inside a character data".to_string())
 );
 
 test!(
@@ -1010,5 +989,5 @@ test!(
     "<p>\u{0c}</p>",
     Token::ElementStart("", "p", 0),
     Token::ElementEnd(ElementEnd::Open, 2..3),
-    Token::Error("a non-XML character '\\u{c}' found at 1:4".to_string())
+    Token::Error(3, "a non-XML character '\\u{c}' found".to_string())
 );

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -147,32 +147,32 @@ fn text_pos_01() {
     let node = doc.root_element();
 
     assert_eq!(
-        doc.text_pos_at(doc.root().range().start),
+        text_pos(data, doc.root().range().start),
         TextPos::new(1, 1)
     );
-    assert_eq!(doc.text_pos_at(doc.root().range().end), TextPos::new(5, 1));
+    assert_eq!(text_pos(data, doc.root().range().end), TextPos::new(5, 1));
 
-    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));
-    assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(4, 5));
+    assert_eq!(text_pos(data, node.range().start), TextPos::new(1, 1));
+    assert_eq!(text_pos(data, node.range().end), TextPos::new(4, 5));
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 9));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 7));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 8));
+        assert_eq!(text_pos(data, attr.range().start), TextPos::new(1, 4));
+        assert_eq!(text_pos(data, attr.range().end), TextPos::new(1, 9));
+        assert_eq!(text_pos(data, attr.range_qname().start), TextPos::new(1, 4));
+        assert_eq!(text_pos(data, attr.range_qname().end), TextPos::new(1, 5));
+        assert_eq!(text_pos(data, attr.range_value().start), TextPos::new(1, 7));
+        assert_eq!(text_pos(data, attr.range_value().end), TextPos::new(1, 8));
     }
 
     // first child is a text/whitespace, not a comment
     let comm = node.first_child().unwrap().next_sibling().unwrap();
-    assert_eq!(doc.text_pos_at(comm.range().start), TextPos::new(2, 5));
+    assert_eq!(text_pos(data, comm.range().start), TextPos::new(2, 5));
 
     let p = comm.next_sibling().unwrap().next_sibling().unwrap();
-    assert_eq!(doc.text_pos_at(p.range().start), TextPos::new(3, 5));
+    assert_eq!(text_pos(data, p.range().start), TextPos::new(3, 5));
 
     let text = p.first_child().unwrap();
-    assert_eq!(doc.text_pos_at(text.range().start), TextPos::new(3, 8));
+    assert_eq!(text_pos(data, text.range().start), TextPos::new(3, 8));
 }
 
 #[cfg(feature = "positions")]
@@ -183,15 +183,15 @@ fn text_pos_02() {
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
 
-    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));
+    assert_eq!(text_pos(data, node.range().start), TextPos::new(1, 1));
 
     if let Some(attr) = node.attribute_node(("http://www.w3.org", "a")) {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 44));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 43));
+        assert_eq!(text_pos(data, attr.range().start), TextPos::new(1, 36));
+        assert_eq!(text_pos(data, attr.range().end), TextPos::new(1, 44));
+        assert_eq!(text_pos(data, attr.range_qname().start), TextPos::new(1, 36));
+        assert_eq!(text_pos(data, attr.range_qname().end), TextPos::new(1, 40));
+        assert_eq!(text_pos(data, attr.range_value().start), TextPos::new(1, 42));
+        assert_eq!(text_pos(data, attr.range_value().end), TextPos::new(1, 43));
     }
 }
 
@@ -206,8 +206,8 @@ fn text_pos_03() {
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
 
-    assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(2, 1));
-    assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(2, 5));
+    assert_eq!(text_pos(data, node.range().start), TextPos::new(2, 1));
+    assert_eq!(text_pos(data, node.range().end), TextPos::new(2, 5));
 }
 
 #[cfg(feature = "positions")]
@@ -219,12 +219,12 @@ fn text_pos_04() {
     let node = doc.root_element();
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 43));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 42));
+        assert_eq!(text_pos(data, attr.range().start), TextPos::new(1, 36));
+        assert_eq!(text_pos(data, attr.range().end), TextPos::new(1, 43));
+        assert_eq!(text_pos(data, attr.range_qname().start), TextPos::new(1, 36));
+        assert_eq!(text_pos(data, attr.range_qname().end), TextPos::new(1, 40));
+        assert_eq!(text_pos(data, attr.range_value().start), TextPos::new(1, 42));
+        assert_eq!(text_pos(data, attr.range_value().end), TextPos::new(1, 42));
 }
 }
 
@@ -237,12 +237,12 @@ fn text_pos_05() {
     let node = doc.root_element();
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 48));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 47));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 48));
+        assert_eq!(text_pos(data, attr.range().start), TextPos::new(1, 36));
+        assert_eq!(text_pos(data, attr.range().end), TextPos::new(1, 48));
+        assert_eq!(text_pos(data, attr.range_qname().start), TextPos::new(1, 36));
+        assert_eq!(text_pos(data, attr.range_qname().end), TextPos::new(1, 40));
+        assert_eq!(text_pos(data, attr.range_value().start), TextPos::new(1, 47));
+        assert_eq!(text_pos(data, attr.range_value().end), TextPos::new(1, 48));
     }
 }
 
@@ -256,12 +256,36 @@ fn text_pos_06() {
     let node = doc.root_element();
 
     if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 269));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
+        assert_eq!(text_pos(data, attr.range().start), TextPos::new(1, 4));
+        assert_eq!(text_pos(data, attr.range().end), TextPos::new(1, 269));
+        assert_eq!(text_pos(data, attr.range_qname().start), TextPos::new(1, 4));
+        assert_eq!(text_pos(data, attr.range_qname().end), TextPos::new(1, 5));
         attr.range_value(); // unreliable since >254 spaces around equal sign, but still shouldn't panic
     }
+}
+
+#[test]
+fn text_pos_07() {
+    assert_eq!(
+        text_pos("text", 2),
+        crate::TextPos::new(1, 3),
+    );
+}
+
+#[test]
+fn text_pos_08() {
+    assert_eq!(
+        text_pos("text\ntext", 6),
+        crate::TextPos::new(2, 2),
+    );
+}
+
+#[test]
+fn text_pos_09() {
+    assert_eq!(
+        text_pos("текст\nтекст", 15),
+        crate::TextPos::new(2, 3),
+    );
 }
 
 #[test]

--- a/tests/ast.rs
+++ b/tests/ast.rs
@@ -28,7 +28,14 @@ fn actual_test(path: &str) {
     let doc = match Document::parse_with_options(&input_xml, opt) {
         Ok(v) => v,
         Err(e) => {
-            assert_eq!(TStr(&format!("error: \"{}\"", e)), TStr(expected.trim()));
+            assert_eq!(
+                TStr(&format!(
+                    "error: \"{} at {}\"",
+                    e,
+                    text_pos(&input_xml, e.pos()),
+                )),
+                TStr(expected.trim())
+            );
             return;
         }
     };

--- a/tests/files/attrs_err_001.yaml
+++ b/tests/files/attrs_err_001.yaml
@@ -1,1 +1,1 @@
-error: "attribute 'a' at 1:11 is already defined"
+error: "attribute 'a' is already defined at 1:11"

--- a/tests/files/attrs_err_002.yaml
+++ b/tests/files/attrs_err_002.yaml
@@ -1,1 +1,1 @@
-error: "attribute 'a' at 1:72 is already defined"
+error: "attribute 'a' is already defined at 1:72"

--- a/tests/files/ns_err_004.yaml
+++ b/tests/files/ns_err_004.yaml
@@ -1,1 +1,1 @@
-error: "namespace 'n' at 1:34 is already defined"
+error: "namespace 'n' is already defined at 1:34"

--- a/tests/files/ns_err_007.yaml
+++ b/tests/files/ns_err_007.yaml
@@ -1,1 +1,1 @@
-error: "the 'xmlns' URI is used at 1:6, but it must not be declared"
+error: "the 'xmlns' URI must not be declared, but is used at 1:6"

--- a/tests/files/ns_err_008.yaml
+++ b/tests/files/ns_err_008.yaml
@@ -1,1 +1,1 @@
-error: "the 'xmlns' URI is used at 1:6, but it must not be declared"
+error: "the 'xmlns' URI must not be declared, but is used at 1:6"

--- a/tests/files/ns_err_009.yaml
+++ b/tests/files/ns_err_009.yaml
@@ -1,1 +1,1 @@
-error: "the 'xmlns' prefix is used at 1:2, but it must not be"
+error: "the 'xmlns' prefix must not be used, but is at 1:2"

--- a/tests/files/tree_err_001.yaml
+++ b/tests/files/tree_err_001.yaml
@@ -1,1 +1,1 @@
-error: "the document does not have a root node"
+error: "the document does not have a root node at 1:1"

--- a/tests/files/tree_err_002.yaml
+++ b/tests/files/tree_err_002.yaml
@@ -1,1 +1,1 @@
-error: "the root node was opened but never closed"
+error: "the root node was opened but never closed at 1:1"


### PR DESCRIPTION
This adds support for error handling scenarios where callers need the byte offset where an error occurred rather than the `TextPos`.  Since `TextPos` is calculated from a byte offset (and the source string), the best way to provide support for both situations is to store the byte offset in `Error` and then supply an easy way for the caller to translate it into a `TextPos`.

FIX: Callers that want to continue displaying the `TextPos` (i.e. line/col) for an error will need to refactor their error handling code to create that `TextPos` by calling the new `text_pos` free function, passing the original XML string and the result from `Error::pos()` (which is now a `usize` instead of a `TextPos`).

Breakdown of changes:
* Change all `TextPos` data in `Error` to `usize`.
* Change `Error` variants without position data to return `0` from `pos` method.
* Remove position info from `Error` `Display` strings, allowing the caller to provide position info in the manner of their choosing.  Rephrase a few error strings where the position was in the middle of the string.
* Fix up all the places that create errors.
* Refactor `Stream::gen_text_pos[_from]` and `Document::text_pos_at` into new lib-level free function `text_pos`.
* Refactor `text_pos_*` tests in `tokenizer_tests` to just test the new `text_pos` function.  Move them to the `api` tests and renumber them to not conflict with the text pos tests already in that file.
* Add position field to `Token::Error` in `tokenizer_tests` so that expected error positions are still verified even though they're not included in the `Display` strings anymore.
* Change `ast` test function to concat error strings and their `TextPos` before comparing to the expected file/message.

Questions:
* When I rephrased error messages it was pretty mechanical, better suggestions are welcome.
* The changes in `ast` tests were the minimal needed to get them working without losing functionality.  I suggest that it might be preferable to store the expected byte position separately from the message in the yaml file, but I'm not sure what the preferred way to do that would be.