### PR TITLE
Add support for resolving external entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `ParsingOptions::entity_resolver` can be used to resolve external entities referenced via public ID and URI.
+
 ### Changed
 - `Node::has_attribute`, `Node::attribute` and `Node::attribute_node` now match local names similar to how `Node::has_tag_name` works.
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -363,3 +363,27 @@ fn tag_name_lifetime() {
     let root = doc.root_element();
     assert_eq!(get_tag_name(&root), "e");
 }
+
+#[test]
+fn entity_resolver_works() {
+    let text = r#"<!DOCTYPE foo [<!ENTITY bar SYSTEM "baz.xml">]> <qux>&bar;</qux>"#;
+
+    let mut entity_resolver =
+        |_pub_id: Option<&str>, _uri: &str| Ok(Some(r#"<?xml version="1.0"?><foobar/>"#));
+
+    let opts = roxmltree::ParsingOptions {
+        allow_dtd: true,
+        entity_resolver: Some(&mut entity_resolver),
+        ..Default::default()
+    };
+
+    let doc = roxmltree::Document::parse_with_options(text, opts).unwrap();
+
+    assert!(
+        doc.root_element()
+            .children()
+            .next()
+            .unwrap()
+            .has_tag_name("foobar")
+    );
+}


### PR DESCRIPTION
This adds minimal support for resolving external entities by enabling the user to supply a resolver which can act on the public ID and URI defining the entity.

Fixes #146 