### PR TITLE
Adjust attribute accessors to match purely on local names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- `Node::has_attribute`, `Node::attribute` and `Node::attribute_node` now match local names similar to how `Node::has_tag_name` works.
 
 ## [0.20.0] - 2024-05-23
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1125,10 +1125,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     where
         N: Into<ExpandedName<'n, 'm>>,
     {
-        let name = name.into();
-        self.attributes()
-            .find(|a| a.data.name.as_expanded_name(self.doc) == name)
-            .map(|a| a.value())
+        self.attribute_node(name).map(|a| a.value())
     }
 
     /// Returns element's attribute object.
@@ -1141,8 +1138,11 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
         N: Into<ExpandedName<'n, 'm>>,
     {
         let name = name.into();
-        self.attributes()
-            .find(|a| a.data.name.as_expanded_name(self.doc) == name)
+
+        match name.namespace() {
+            Some(_) => self.attributes().find(|a| a.data.name.as_expanded_name(self.doc) == name),
+            None => self.attributes().find(|a| a.data.name.local_name == name.name),
+        }
     }
 
     /// Checks that element has a specified attribute.
@@ -1164,9 +1164,7 @@ impl<'a, 'input: 'a> Node<'a, 'input> {
     where
         N: Into<ExpandedName<'n, 'm>>,
     {
-        let name = name.into();
-        self.attributes()
-            .any(|a| a.data.name.as_expanded_name(self.doc) == name)
+        self.attribute_node(name).is_some()
     }
 
     /// Returns element's attributes.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -374,7 +374,7 @@ impl<'input> Document<'input> {
     /// assert_eq!(doc.descendants().count(), 2); // root node + `e` element node
     /// ```
     #[inline]
-    pub fn parse(text: &str) -> Result<Document> {
+    pub fn parse(text: &'input str) -> Result<Self> {
         Self::parse_with_options(text, ParsingOptions::default())
     }
 
@@ -391,7 +391,7 @@ impl<'input> Document<'input> {
     /// assert_eq!(doc.descendants().count(), 2); // root node + `e` element node
     /// ```
     #[inline]
-    pub fn parse_with_options(text: &str, opt: ParsingOptions) -> Result<Document> {
+    pub fn parse_with_options(text: &'input str, opt: ParsingOptions) -> Result<Self> {
         parse(text, opt)
     }
 }
@@ -595,7 +595,7 @@ impl<'input> Context<'input> {
     }
 }
 
-fn parse(text: &str, opt: ParsingOptions) -> Result<Document> {
+fn parse<'input>(text: &'input str, opt: ParsingOptions) -> Result<Document<'input>> {
     // Trying to guess rough nodes and attributes amount.
     let nodes_capacity = memchr_iter(b'<', text.as_bytes()).count();
     let attributes_capacity = memchr_iter(b'=', text.as_bytes()).count();

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -170,7 +170,7 @@ impl<'input> From<&'input str> for StrSpan<'input> {
 
 impl<'input> StrSpan<'input> {
     #[inline]
-    pub fn from_substr(text: &str, start: usize, end: usize) -> StrSpan {
+    pub fn from_substr(text: &'input str, start: usize, end: usize) -> Self {
         debug_assert!(start <= end);
         StrSpan {
             text: &text[start..end],

--- a/src/tokenizer_tests.rs
+++ b/src/tokenizer_tests.rs
@@ -110,7 +110,7 @@ impl<'a> xml::XmlEvents<'a> for EventsCollector<'a> {
 }
 
 #[inline(never)]
-pub fn collect_tokens(text: &str) -> Vec<Token> {
+pub fn collect_tokens(text: &str) -> Vec<Token<'_>> {
     let mut collector = EventsCollector { tokens: Vec::new() };
     if let Err(e) = xml::parse(text, true, &mut collector) {
         collector.tokens.push(Token::Error(e.to_string()));

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -310,8 +310,8 @@ fn nodes_document_order() {
     let b = a.next_sibling_element().unwrap();
     let c = b.next_sibling_element().unwrap();
 
-    let mut elems = vec![&b, &c, &a];
-    elems.sort();
+    let mut elems = [&b, &c, &a];
+    elems.sort_unstable();
     assert!(elems[0] == &a);
     assert!(elems[1] == &b);
     assert!(elems[2] == &c);

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -63,7 +63,7 @@ fn api_01() {
     let doc = Document::parse(data).unwrap();
     let p = doc.root_element();
 
-    assert_eq!(p.attribute("attr"), Some("no_ns"));
+    assert_eq!(p.attributes().find(|a| a.namespace().is_none() && a.name() == "attr").map(|a| a.value()), Some("no_ns"));
     assert_eq!(p.has_attribute("attr"), true);
 
     assert_eq!(p.attribute(("http://www.w3.org", "attr")), Some("a_ns"));
@@ -80,6 +80,18 @@ fn api_01() {
 
     assert_eq!(p.attribute("xmlns"), None);
     assert_eq!(p.has_attribute("xmlns"), false);
+}
+
+#[test]
+fn has_local_name() {
+    let doc = Document::parse(r#"<root xmlns:foo="http://example.com/foo"><foo:bar foo:baz="qux"/></root>"#).unwrap();
+
+    let node = doc.descendants().next_back().unwrap();
+
+    assert_eq!(node.has_tag_name("bar"), true);
+
+    assert_eq!(node.has_attribute("baz"), true);
+    assert_eq!(node.attribute("baz"), Some("qux"));
 }
 
 #[test]
@@ -145,6 +157,7 @@ fn text_pos_01() {
 
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
+    let attr = node.attribute_node("a").unwrap();
 
     assert_eq!(
         doc.text_pos_at(doc.root().range().start),
@@ -155,14 +168,12 @@ fn text_pos_01() {
     assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));
     assert_eq!(doc.text_pos_at(node.range().end), TextPos::new(4, 5));
 
-    if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 9));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 7));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 8));
-    }
+    assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
+    assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 9));
+    assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
+    assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
+    assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 7));
+    assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 8));
 
     // first child is a text/whitespace, not a comment
     let comm = node.first_child().unwrap().next_sibling().unwrap();
@@ -182,17 +193,16 @@ fn text_pos_02() {
 
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
+    let attr = node.attribute_node(("http://www.w3.org", "a")).unwrap();
 
     assert_eq!(doc.text_pos_at(node.range().start), TextPos::new(1, 1));
 
-    if let Some(attr) = node.attribute_node(("http://www.w3.org", "a")) {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 44));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 43));
-    }
+    assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
+    assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 44));
+    assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
+    assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
+    assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
+    assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 43));
 }
 
 #[cfg(feature = "positions")]
@@ -217,15 +227,14 @@ fn text_pos_04() {
 
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
+    let attr = node.attribute_node("a").unwrap();
 
-    if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 43));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 42));
-}
+    assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
+    assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 43));
+    assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
+    assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
+    assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 42));
+    assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 42));
 }
 
 #[cfg(feature = "positions")]
@@ -235,15 +244,14 @@ fn text_pos_05() {
 
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
+    let attr = node.attribute_node("a").unwrap();
 
-    if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 48));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
-        assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 47));
-        assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 48));
-    }
+    assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 36));
+    assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 49));
+    assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 36));
+    assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 40));
+    assert_eq!(doc.text_pos_at(attr.range_value().start), TextPos::new(1, 47));
+    assert_eq!(doc.text_pos_at(attr.range_value().end), TextPos::new(1, 48));
 }
 
 #[cfg(feature = "positions")]
@@ -254,14 +262,13 @@ fn text_pos_06() {
 
     let doc = Document::parse(data).unwrap();
     let node = doc.root_element();
+    let attr = node.attribute_node("a").unwrap();
 
-    if let Some(attr) = node.attribute_node("a") {
-        assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 269));
-        assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
-        assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
-        attr.range_value(); // unreliable since >254 spaces around equal sign, but still shouldn't panic
-    }
+    assert_eq!(doc.text_pos_at(attr.range().start), TextPos::new(1, 4));
+    assert_eq!(doc.text_pos_at(attr.range().end), TextPos::new(1, 269));
+    assert_eq!(doc.text_pos_at(attr.range_qname().start), TextPos::new(1, 4));
+    assert_eq!(doc.text_pos_at(attr.range_qname().end), TextPos::new(1, 5));
+    attr.range_value(); // unreliable since >254 spaces around equal sign, but still shouldn't panic
 }
 
 #[test]

--- a/tests/dom-api.rs
+++ b/tests/dom-api.rs
@@ -132,7 +132,7 @@ fn last_element_child() {
     let elem = svg_elem
         .children()
         .filter(|n| n.is_element())
-        .last()
+        .next_back()
         .unwrap();
     assert!(elem.has_tag_name("rect"));
 }


### PR DESCRIPTION
This makes them less precise but more convenient. The manual approach of iterating attributes still exists, so this does not make any access patterns impossible.

Fixes #145 